### PR TITLE
WIP: Create a plugin component to override file previews

### DIFF
--- a/components/file_attachment_list/__snapshots__/file_attachment_list.test.jsx.snap
+++ b/components/file_attachment_list/__snapshots__/file_attachment_list.test.jsx.snap
@@ -72,6 +72,16 @@ exports[`components/FileAttachmentList should match snapshot, multiple files ord
       ]
     }
     onModalDismissed={[Function]}
+    post={
+      Object {
+        "file_ids": Array [
+          "file_id_1",
+          "file_id_2",
+          "file_id_3",
+        ],
+        "id": "post_id",
+      }
+    }
     show={false}
     startIndex={0}
   />
@@ -89,6 +99,13 @@ exports[`components/FileAttachmentList should match snapshot, single image view 
     }
   }
   isEmbedVisible={false}
-  postId="post_id"
+  post={
+    Object {
+      "file_ids": Array [
+        "file_id_1",
+      ],
+      "id": "post_id",
+    }
+  }
 />
 `;

--- a/components/file_attachment_list/file_attachment_list.jsx
+++ b/components/file_attachment_list/file_attachment_list.jsx
@@ -88,7 +88,7 @@ export default class FileAttachmentList extends React.Component {
                         <SingleImageView
                             fileInfo={fileInfos[0]}
                             isEmbedVisible={this.props.isEmbedVisible}
-                            postId={this.props.post.id}
+                            post={this.props.post}
                         />
                     );
                 }
@@ -136,6 +136,7 @@ export default class FileAttachmentList extends React.Component {
                     onModalDismissed={this.hidePreviewModal}
                     startIndex={this.state.startImgIndex}
                     fileInfos={sortedFileInfos}
+                    post={this.props.post}
                 />
             </React.Fragment>
         );

--- a/components/post_view/post_body_additional_content/post_body_additional_content.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.jsx
@@ -286,6 +286,7 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
             <ViewImageModal
                 show={this.state.showPreviewModal}
                 onModalDismissed={() => this.setState({showPreviewModal: false})}
+                post={this.props.post}
                 startIndex={0}
                 fileInfos={[{
                     has_preview_image: false,

--- a/components/single_image_view/__snapshots__/single_image_view.test.jsx.snap
+++ b/components/single_image_view/__snapshots__/single_image_view.test.jsx.snap
@@ -111,6 +111,11 @@ exports[`components/SingleImageView should match snapshot 2`] = `
         ]
       }
       onModalDismissed={[Function]}
+      post={
+        Object {
+          "id": "original_post_id",
+        }
+      }
       show={false}
     />
   </div>
@@ -235,6 +240,11 @@ exports[`components/SingleImageView should match snapshot, SVG image 2`] = `
         ]
       }
       onModalDismissed={[Function]}
+      post={
+        Object {
+          "id": "original_post_id",
+        }
+      }
       show={false}
     />
   </div>
@@ -302,6 +312,11 @@ exports[`components/SingleImageView should set loaded state on callback of onIma
         ]
       }
       onModalDismissed={[Function]}
+      post={
+        Object {
+          "id": "original_post_id",
+        }
+      }
       show={false}
     />
   </div>

--- a/components/single_image_view/single_image_view.jsx
+++ b/components/single_image_view/single_image_view.jsx
@@ -18,7 +18,7 @@ const PREVIEW_IMAGE_MIN_DIMENSION = 50;
 
 export default class SingleImageView extends React.PureComponent {
     static propTypes = {
-        postId: PropTypes.string.isRequired,
+        post: PropTypes.object.isRequired,
         fileInfo: PropTypes.object.isRequired,
         isRhsOpen: PropTypes.bool.isRequired,
         isEmbedVisible: PropTypes.bool,
@@ -79,7 +79,7 @@ export default class SingleImageView extends React.PureComponent {
     }
 
     toggleEmbedVisibility = () => {
-        this.props.actions.toggleEmbedVisibility(this.props.postId);
+        this.props.actions.toggleEmbedVisibility(this.props.post.id);
     }
 
     render() {
@@ -153,6 +153,7 @@ export default class SingleImageView extends React.PureComponent {
                     show={this.state.showPreviewModal}
                     onModalDismissed={this.showPreviewModal}
                     fileInfos={[fileInfo]}
+                    post={this.props.post}
                 />
             );
 

--- a/components/single_image_view/single_image_view.test.jsx
+++ b/components/single_image_view/single_image_view.test.jsx
@@ -9,7 +9,9 @@ import SizeAwareImage from 'components/size_aware_image';
 
 describe('components/SingleImageView', () => {
     const baseProps = {
-        postId: 'original_post_id',
+        post: {
+            id: 'original_post_id',
+        },
         fileInfo: {
             id: 'file_info_id',
             post_id: 'post_id',

--- a/components/view_image/__snapshots__/view_image.test.jsx.snap
+++ b/components/view_image/__snapshots__/view_image.test.jsx.snap
@@ -1,5 +1,76 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`components/ViewImageModal should fall back to default preview if plugin does not need to override preview component 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  className="modal-image"
+  dialogClassName="modal-image"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onHide={[MockFunction]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalBody
+    bsClass="modal-body"
+    componentClass="div"
+  >
+    <div
+      className="modal-image__wrapper"
+      onClick={[MockFunction]}
+    >
+      <div
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        <div
+          className="modal-close"
+          onClick={[MockFunction]}
+        />
+        <div
+          className="modal-image__content"
+        >
+          <LoadingImagePreview
+            containerClass="view-image__loading"
+            loading="Loading"
+            progress={0}
+          />
+        </div>
+        <Connect(PopoverBar)
+          canDownloadFiles={true}
+          enablePublicLink={true}
+          fileIndex={0}
+          fileURL="/api/v4/files/file_id?download=1"
+          isExternalFile={false}
+          onGetPublicLink={[Function]}
+          show={false}
+          showPublicLink={true}
+          totalFiles={1}
+        />
+      </div>
+    </div>
+  </ModalBody>
+</Modal>
+`;
+
 exports[`components/ViewImageModal should match snapshot for external file 1`] = `
 <Modal
   animation={true}
@@ -257,6 +328,81 @@ exports[`components/ViewImageModal should match snapshot on onModalShown and onM
         className="image-control image-next"
       />
     </a>
+  </ModalBody>
+</Modal>
+`;
+
+exports[`components/ViewImageModal should match snapshot when plugin overrides the preview component 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  className="modal-image"
+  dialogClassName="modal-image"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onHide={[MockFunction]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalBody
+    bsClass="modal-body"
+    componentClass="div"
+  >
+    <div
+      className="modal-image__wrapper"
+      onClick={[MockFunction]}
+    >
+      <div
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        <div
+          className="modal-close"
+          onClick={[MockFunction]}
+        />
+        <div
+          className="modal-image__content"
+        >
+          <component
+            fileInfo={
+              Object {
+                "extension": "jpg",
+                "id": "file_id",
+              }
+            }
+            post={Object {}}
+          />
+        </div>
+        <Connect(PopoverBar)
+          canDownloadFiles={true}
+          enablePublicLink={true}
+          fileIndex={0}
+          fileURL="/api/v4/files/file_id?download=1"
+          isExternalFile={false}
+          onGetPublicLink={[Function]}
+          show={false}
+          showPublicLink={true}
+          totalFiles={1}
+        />
+      </div>
+    </div>
   </ModalBody>
 </Modal>
 `;

--- a/components/view_image/index.js
+++ b/components/view_image/index.js
@@ -14,6 +14,7 @@ function mapStateToProps(state) {
     return {
         canDownloadFiles: canDownloadFiles(config),
         enablePublicLink: config.EnablePublicLink === 'true',
+        pluginFilePreviewComponents: state.plugins.components.FilePreview,
     };
 }
 

--- a/components/view_image/view_image.jsx
+++ b/components/view_image/view_image.jsx
@@ -25,6 +25,11 @@ export default class ViewImageModal extends React.PureComponent {
     static propTypes = {
 
         /**
+         * The post the files are attached to
+         */
+        post: PropTypes.object.isRequired,
+
+        /**
          * Set whether to show this modal or not
          */
         show: PropTypes.bool.isRequired,
@@ -46,12 +51,14 @@ export default class ViewImageModal extends React.PureComponent {
 
         canDownloadFiles: PropTypes.bool.isRequired,
         enablePublicLink: PropTypes.bool.isRequired,
+        pluginFilePreviewComponents: PropTypes.arrayOf(PropTypes.object),
     };
 
     static defaultProps = {
         show: false,
         fileInfos: [],
         startIndex: 0,
+        pluginFilePreviewComponents: [],
     };
 
     constructor(props) {
@@ -260,6 +267,18 @@ export default class ViewImageModal extends React.PureComponent {
                     progress={progress}
                 />
             );
+        }
+
+        for (const preview of this.props.pluginFilePreviewComponents) {
+            if (preview.handler(fileInfo, this.props.post)) {
+                content = (
+                    <preview.component
+                        fileInfo={fileInfo}
+                        post={this.props.post}
+                    />
+                );
+                break;
+            }
         }
 
         let leftArrow = null;

--- a/components/view_image/view_image.test.jsx
+++ b/components/view_image/view_image.test.jsx
@@ -17,6 +17,7 @@ describe('components/ViewImageModal', () => {
         onModalDismissed,
         canDownloadFiles: true,
         enablePublicLink: true,
+        post: {},
     };
 
     test('should match snapshot, modal not shown', () => {

--- a/components/view_image/view_image.test.jsx
+++ b/components/view_image/view_image.test.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import {Modal} from 'react-bootstrap';
 import {shallow} from 'enzyme';
 
+import {generateId} from 'utils/utils.jsx';
 import Constants from 'utils/constants.jsx';
 import ViewImageModal from 'components/view_image/view_image.jsx';
 
@@ -293,5 +294,31 @@ describe('components/ViewImageModal', () => {
         wrapper.setProps(nextProps);
         expect(wrapper.state('loaded').length).toBe(3);
         expect(wrapper.state('progress').length).toBe(3);
+    });
+
+    test('should match snapshot when plugin overrides the preview component', () => {
+        const pluginFilePreviewComponents = [{
+            id: generateId(),
+            pluginId: 'file-preview',
+            handler: () => true,
+            component: () => <div>{'Preview'}</div>,
+        }];
+        const props = {...requiredProps, pluginFilePreviewComponents};
+        const wrapper = shallow(<ViewImageModal {...props}/>);
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should fall back to default preview if plugin does not need to override preview component', () => {
+        const pluginFilePreviewComponents = [{
+            id: generateId(),
+            pluginId: 'file-preview',
+            handler: () => false,
+            component: () => <div>{'Preview'}</div>,
+        }];
+        const props = {...requiredProps, pluginFilePreviewComponents};
+        const wrapper = shallow(<ViewImageModal {...props}/>);
+
+        expect(wrapper).toMatchSnapshot();
     });
 });

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -308,4 +308,27 @@ export default class PluginRegistry {
 
         return id;
     }
+
+    // Register a component to override file previews. Accepts a function to run before file is
+    // previewed and a react component to be rendered as the file preview.
+    // - handler - A function to check whether preview needs to be overridden. Receives fileInfo and post as arguments.
+    // Returns true is preview should be overridden and false otherwise.
+    // - component - A react component to display instead of original preview. Receives fileInfo and post as props.
+    // Returns a unique identifier.
+    registerFilePreviewComponent(handler, component) {
+        const id = generateId();
+
+        store.dispatch({
+            type: ActionTypes.RECEIVED_PLUGIN_COMPONENT,
+            name: 'FilePreview',
+            data: {
+                id,
+                pluginId: this.id,
+                handler,
+                component,
+            },
+        });
+
+        return id;
+    }
 }


### PR DESCRIPTION
#### Summary
- Add a plugin component to override file previews.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (file preview)
