### PR TITLE
Pulsating dot and post header components

### DIFF
--- a/actions/views/custom_status.ts
+++ b/actions/views/custom_status.ts
@@ -6,7 +6,6 @@ import {updateMe} from 'mattermost-redux/actions/users';
 import {DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 
 import {CustomStatus, CustomStatusInitialisationStates} from 'types/store/custom_status';
-import Constants from 'utils/constants';
 
 export function updateUserCustomStatus(newCustomStatus: CustomStatus) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
@@ -54,15 +53,6 @@ export function setCustomStatusInitialisationState(props: Partial<CustomStatusIn
         const userProps = {...user.props};
         let initialState = userProps.customStatusInitialisationState ? JSON.parse(userProps.customStatusInitialisationState) : {};
         initialState = {...initialState, ...props};
-        if (initialState.menuOpenedOnClick === Constants.CustomStatusInitialisationStates.MENU_OPENED_BY_SIDEBAR_HEADER) {
-            if (initialState.hasClickedSidebarHeaderFirstTime === undefined) {
-                initialState.hasClickedSidebarHeaderFirstTime = true;
-            } else {
-                initialState.hasClickedSidebarHeaderFirstTime = false;
-            }
-        }
-
-        initialState.hasClickedUpdateStatusBefore = initialState.hasClickedUpdateStatusBefore || initialState.menuOpenedOnClick === Constants.CustomStatusInitialisationStates.MENU_OPENED_BY_POST_HEADER;
         userProps.customStatusInitialisationState = JSON.stringify(initialState);
         user.props = userProps;
         await dispatch(updateMe(user));

--- a/actions/views/custom_status.ts
+++ b/actions/views/custom_status.ts
@@ -5,43 +5,25 @@ import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {updateMe} from 'mattermost-redux/actions/users';
 import {DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 
-import {CustomStatus} from 'types/store/custom_status';
+import {CustomStatusInitialisationStates} from 'types/store/custom_status';
 
-export function updateUserCustomStatus(newCustomStatus: CustomStatus) {
+export function setCustomStatusInitialisationState(props: Partial<CustomStatusInitialisationStates>) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const user = {...getCurrentUser(getState())};
         const userProps = {...user.props};
-        const recentCustomStatuses = userProps.recentCustomStatuses ? JSON.parse(userProps.recentCustomStatuses) : [];
-        const updatedRecentCustomStatuses = [
-            newCustomStatus,
-            ...recentCustomStatuses.
-                filter((status: CustomStatus) => status.text !== newCustomStatus.text).
-                slice(0, 4),
-        ];
-        userProps.customStatus = JSON.stringify(newCustomStatus);
-        userProps.recentCustomStatuses = JSON.stringify(updatedRecentCustomStatuses);
+        let initialState = userProps.customStatusInitialisationState ? JSON.parse(userProps.customStatusInitialisationState) : {};
+        initialState = {...initialState, ...props};
+        userProps.customStatusInitialisationState = JSON.stringify(initialState);
         user.props = userProps;
         await dispatch(updateMe(user));
     };
 }
 
-export function unsetUserCustomStatus() {
+export function clearCustomStatusInitialisationState() {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const user = {...getCurrentUser(getState())};
         const userProps = {...user.props};
-        delete userProps.customStatus;
-        user.props = userProps;
-        await dispatch(updateMe(user));
-    };
-}
-
-export function removeRecentCustomStatus(status: CustomStatus) {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const user = {...getCurrentUser(getState())};
-        const userProps = {...user.props};
-        const recentCustomStatuses = userProps.recentCustomStatuses ? JSON.parse(userProps.recentCustomStatuses) : [];
-        const updatedRecentCustomStatuses = recentCustomStatuses.filter((recentStatus: CustomStatus) => recentStatus.text !== status.text);
-        userProps.recentCustomStatuses = JSON.stringify(updatedRecentCustomStatuses);
+        userProps.customStatusInitialisationState = '';
         user.props = userProps;
         await dispatch(updateMe(user));
     };

--- a/actions/views/custom_status.ts
+++ b/actions/views/custom_status.ts
@@ -47,11 +47,11 @@ export function removeRecentCustomStatus(status: CustomStatus) {
     };
 }
 
-export function setFirstTimeUserProperties(property: string) {
+export function setCustomStatusInitialProps(prop: string) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const user = {...getCurrentUser(getState())};
         const userProps = {...user.props};
-        userProps.initialProps = property;
+        userProps.initialProps = prop;
         user.props = userProps;
         await dispatch(updateMe(user));
     };

--- a/actions/views/custom_status.ts
+++ b/actions/views/custom_status.ts
@@ -46,3 +46,13 @@ export function removeRecentCustomStatus(status: CustomStatus) {
         await dispatch(updateMe(user));
     };
 }
+
+export function setFirstTimeUserProperties(property: string) {
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const user = {...getCurrentUser(getState())};
+        const userProps = {...user.props};
+        userProps.initialProps = property;
+        user.props = userProps;
+        await dispatch(updateMe(user));
+    };
+}

--- a/actions/views/custom_status.ts
+++ b/actions/views/custom_status.ts
@@ -5,7 +5,7 @@ import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {updateMe} from 'mattermost-redux/actions/users';
 import {DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 
-import {CustomStatus, CustomStatusInitialProps} from 'types/store/custom_status';
+import {CustomStatus, CustomStatusInitialisationState} from 'types/store/custom_status';
 import Constants from 'utils/constants';
 
 export function updateUserCustomStatus(newCustomStatus: CustomStatus) {
@@ -48,32 +48,32 @@ export function removeRecentCustomStatus(status: CustomStatus) {
     };
 }
 
-export function setCustomStatusInitialProps(props: Partial<CustomStatusInitialProps>) {
+export function setCustomStatusInitialisationState(props: Partial<CustomStatusInitialisationState>) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const user = {...getCurrentUser(getState())};
         const userProps = {...user.props};
-        let initialProps = userProps.initialProps ? JSON.parse(userProps.initialProps) : {};
-        initialProps = {...initialProps, ...props};
-        if (initialProps.menuOpenedOnClick === Constants.CustomStatusInitialProps.MENU_OPENED_BY_SIDEBAR_HEADER) {
-            if (initialProps.hasClickedSidebarHeaderFirstTime === undefined) {
-                initialProps.hasClickedSidebarHeaderFirstTime = true;
+        let initialState = userProps.customStatusInitialisationState ? JSON.parse(userProps.customStatusInitialisationState) : {};
+        initialState = {...initialState, ...props};
+        if (initialState.menuOpenedOnClick === Constants.CustomStatusInitialisationState.MENU_OPENED_BY_SIDEBAR_HEADER) {
+            if (initialState.hasClickedSidebarHeaderFirstTime === undefined) {
+                initialState.hasClickedSidebarHeaderFirstTime = true;
             } else {
-                initialProps.hasClickedSidebarHeaderFirstTime = false;
+                initialState.hasClickedSidebarHeaderFirstTime = false;
             }
         }
 
-        initialProps.hasClickedUpdateStatusBefore = initialProps.hasClickedUpdateStatusBefore || initialProps.menuOpenedOnClick === Constants.CustomStatusInitialProps.MENU_OPENED_BY_POST_HEADER;
-        userProps.initialProps = JSON.stringify(initialProps);
+        initialState.hasClickedUpdateStatusBefore = initialState.hasClickedUpdateStatusBefore || initialState.menuOpenedOnClick === Constants.CustomStatusInitialisationState.MENU_OPENED_BY_POST_HEADER;
+        userProps.customStatusInitialisationState = JSON.stringify(initialState);
         user.props = userProps;
         await dispatch(updateMe(user));
     };
 }
 
-export function clearCustomStatusInitialProps() {
+export function clearCustomStatusInitialisationState() {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const user = {...getCurrentUser(getState())};
         const userProps = {...user.props};
-        userProps.initialProps = '';
+        userProps.customStatusInitialisationState = '';
         user.props = userProps;
         await dispatch(updateMe(user));
     };

--- a/actions/views/custom_status.ts
+++ b/actions/views/custom_status.ts
@@ -5,7 +5,7 @@ import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {updateMe} from 'mattermost-redux/actions/users';
 import {DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 
-import {CustomStatus, CustomStatusInitialisationState} from 'types/store/custom_status';
+import {CustomStatus, CustomStatusInitialisationStates} from 'types/store/custom_status';
 import Constants from 'utils/constants';
 
 export function updateUserCustomStatus(newCustomStatus: CustomStatus) {
@@ -48,13 +48,13 @@ export function removeRecentCustomStatus(status: CustomStatus) {
     };
 }
 
-export function setCustomStatusInitialisationState(props: Partial<CustomStatusInitialisationState>) {
+export function setCustomStatusInitialisationState(props: Partial<CustomStatusInitialisationStates>) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const user = {...getCurrentUser(getState())};
         const userProps = {...user.props};
         let initialState = userProps.customStatusInitialisationState ? JSON.parse(userProps.customStatusInitialisationState) : {};
         initialState = {...initialState, ...props};
-        if (initialState.menuOpenedOnClick === Constants.CustomStatusInitialisationState.MENU_OPENED_BY_SIDEBAR_HEADER) {
+        if (initialState.menuOpenedOnClick === Constants.CustomStatusInitialisationStates.MENU_OPENED_BY_SIDEBAR_HEADER) {
             if (initialState.hasClickedSidebarHeaderFirstTime === undefined) {
                 initialState.hasClickedSidebarHeaderFirstTime = true;
             } else {
@@ -62,7 +62,7 @@ export function setCustomStatusInitialisationState(props: Partial<CustomStatusIn
             }
         }
 
-        initialState.hasClickedUpdateStatusBefore = initialState.hasClickedUpdateStatusBefore || initialState.menuOpenedOnClick === Constants.CustomStatusInitialisationState.MENU_OPENED_BY_POST_HEADER;
+        initialState.hasClickedUpdateStatusBefore = initialState.hasClickedUpdateStatusBefore || initialState.menuOpenedOnClick === Constants.CustomStatusInitialisationStates.MENU_OPENED_BY_POST_HEADER;
         userProps.customStatusInitialisationState = JSON.stringify(initialState);
         user.props = userProps;
         await dispatch(updateMe(user));

--- a/actions/views/custom_status.ts
+++ b/actions/views/custom_status.ts
@@ -5,47 +5,7 @@ import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {updateMe} from 'mattermost-redux/actions/users';
 import {DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 
-import {CustomStatus, CustomStatusInitialisationStates} from 'types/store/custom_status';
-
-export function updateUserCustomStatus(newCustomStatus: CustomStatus) {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const user = {...getCurrentUser(getState())};
-        const userProps = {...user.props};
-        const recentCustomStatuses = userProps.recentCustomStatuses ? JSON.parse(userProps.recentCustomStatuses) : [];
-        const updatedRecentCustomStatuses = [
-            newCustomStatus,
-            ...recentCustomStatuses.
-                filter((status: CustomStatus) => status.text !== newCustomStatus.text).
-                slice(0, 4),
-        ];
-        userProps.customStatus = JSON.stringify(newCustomStatus);
-        userProps.recentCustomStatuses = JSON.stringify(updatedRecentCustomStatuses);
-        user.props = userProps;
-        await dispatch(updateMe(user));
-    };
-}
-
-export function unsetUserCustomStatus() {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const user = {...getCurrentUser(getState())};
-        const userProps = {...user.props};
-        delete userProps.customStatus;
-        user.props = userProps;
-        await dispatch(updateMe(user));
-    };
-}
-
-export function removeRecentCustomStatus(status: CustomStatus) {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const user = {...getCurrentUser(getState())};
-        const userProps = {...user.props};
-        const recentCustomStatuses = userProps.recentCustomStatuses ? JSON.parse(userProps.recentCustomStatuses) : [];
-        const updatedRecentCustomStatuses = recentCustomStatuses.filter((recentStatus: CustomStatus) => recentStatus.text !== status.text);
-        userProps.recentCustomStatuses = JSON.stringify(updatedRecentCustomStatuses);
-        user.props = userProps;
-        await dispatch(updateMe(user));
-    };
-}
+import {CustomStatusInitialisationStates} from 'types/store/custom_status';
 
 export function setCustomStatusInitialisationState(props: Partial<CustomStatusInitialisationStates>) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {

--- a/actions/views/custom_status.ts
+++ b/actions/views/custom_status.ts
@@ -5,48 +5,7 @@ import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {updateMe} from 'mattermost-redux/actions/users';
 import {DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 
-import {CustomStatus, CustomStatusInitialisationStates} from 'types/store/custom_status';
-import Constants from 'utils/constants';
-
-export function updateUserCustomStatus(newCustomStatus: CustomStatus) {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const user = {...getCurrentUser(getState())};
-        const userProps = {...user.props};
-        const recentCustomStatuses = userProps.recentCustomStatuses ? JSON.parse(userProps.recentCustomStatuses) : [];
-        const updatedRecentCustomStatuses = [
-            newCustomStatus,
-            ...recentCustomStatuses.
-                filter((status: CustomStatus) => status.text !== newCustomStatus.text).
-                slice(0, 4),
-        ];
-        userProps.customStatus = JSON.stringify(newCustomStatus);
-        userProps.recentCustomStatuses = JSON.stringify(updatedRecentCustomStatuses);
-        user.props = userProps;
-        await dispatch(updateMe(user));
-    };
-}
-
-export function unsetUserCustomStatus() {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const user = {...getCurrentUser(getState())};
-        const userProps = {...user.props};
-        delete userProps.customStatus;
-        user.props = userProps;
-        await dispatch(updateMe(user));
-    };
-}
-
-export function removeRecentCustomStatus(status: CustomStatus) {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const user = {...getCurrentUser(getState())};
-        const userProps = {...user.props};
-        const recentCustomStatuses = userProps.recentCustomStatuses ? JSON.parse(userProps.recentCustomStatuses) : [];
-        const updatedRecentCustomStatuses = recentCustomStatuses.filter((recentStatus: CustomStatus) => recentStatus.text !== status.text);
-        userProps.recentCustomStatuses = JSON.stringify(updatedRecentCustomStatuses);
-        user.props = userProps;
-        await dispatch(updateMe(user));
-    };
-}
+import {CustomStatusInitialisationStates} from 'types/store/custom_status';
 
 export function setCustomStatusInitialisationState(props: Partial<CustomStatusInitialisationStates>) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
@@ -54,15 +13,6 @@ export function setCustomStatusInitialisationState(props: Partial<CustomStatusIn
         const userProps = {...user.props};
         let initialState = userProps.customStatusInitialisationState ? JSON.parse(userProps.customStatusInitialisationState) : {};
         initialState = {...initialState, ...props};
-        if (initialState.menuOpenedOnClick === Constants.CustomStatusInitialisationStates.MENU_OPENED_BY_SIDEBAR_HEADER) {
-            if (initialState.hasClickedSidebarHeaderFirstTime === undefined) {
-                initialState.hasClickedSidebarHeaderFirstTime = true;
-            } else {
-                initialState.hasClickedSidebarHeaderFirstTime = false;
-            }
-        }
-
-        initialState.hasClickedUpdateStatusBefore = initialState.hasClickedUpdateStatusBefore || initialState.menuOpenedOnClick === Constants.CustomStatusInitialisationStates.MENU_OPENED_BY_POST_HEADER;
         userProps.customStatusInitialisationState = JSON.stringify(initialState);
         user.props = userProps;
         await dispatch(updateMe(user));

--- a/actions/views/status_dropdown.test.ts
+++ b/actions/views/status_dropdown.test.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {setStatusDropdown} from 'actions/views/status_dropdown';
+import {isStatusDropdownOpen} from 'selectors/views/status_dropdown';
+import configureStore from 'store';
+
+describe('status_dropdown view actions', () => {
+    const initialState = {
+        views: {
+            statusDropdown: {
+                isOpen: false,
+            },
+        },
+    };
+
+    it('setStatusDropdown should set the status dropdown open or not', () => {
+        const store = configureStore(initialState);
+
+        store.dispatch(setStatusDropdown(false));
+
+        expect(isStatusDropdownOpen(store.getState())).toBe(false);
+
+        store.dispatch(setStatusDropdown(true));
+
+        expect(isStatusDropdownOpen(store.getState())).toBe(true);
+    });
+});

--- a/actions/views/status_dropdown.ts
+++ b/actions/views/status_dropdown.ts
@@ -1,0 +1,14 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {DispatchFunc} from 'mattermost-redux/types/actions';
+
+import {ActionTypes} from 'utils/constants';
+
+export function toggleStatusDropdown(open: boolean) {
+    return (dispatch: DispatchFunc) => {
+        dispatch({
+            type: ActionTypes.STATUS_DROPDOWN_TOGGLE,
+            open,
+        });
+    };
+}

--- a/actions/views/status_dropdown.ts
+++ b/actions/views/status_dropdown.ts
@@ -1,0 +1,14 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {DispatchFunc} from 'mattermost-redux/types/actions';
+
+import {ActionTypes} from 'utils/constants';
+
+export function setStatusDropdown(open: boolean) {
+    return (dispatch: DispatchFunc) => {
+        dispatch({
+            type: ActionTypes.STATUS_DROPDOWN_TOGGLE,
+            open,
+        });
+    };
+}

--- a/actions/views/status_dropdown.ts
+++ b/actions/views/status_dropdown.ts
@@ -4,7 +4,7 @@ import {DispatchFunc} from 'mattermost-redux/types/actions';
 
 import {ActionTypes} from 'utils/constants';
 
-export function toggleStatusDropdown(open: boolean) {
+export function setStatusDropdown(open: boolean) {
     return (dispatch: DispatchFunc) => {
         dispatch({
             type: ActionTypes.STATUS_DROPDOWN_TOGGLE,

--- a/components/channel_header/__snapshots__/channel_header.test.jsx.snap
+++ b/components/channel_header/__snapshots__/channel_header.test.jsx.snap
@@ -1016,6 +1016,256 @@ exports[`components/ChannelHeader should render correct menu when muted 1`] = `
 </div>
 `;
 
+exports[`components/ChannelHeader should render properly when custom status is set 1`] = `
+<div
+  aria-label="channel header region"
+  className="channel-header alt a11y__region"
+  data-a11y-sort-order="8"
+  data-channelid="undefined"
+  id="channel-header"
+  role="banner"
+  tabIndex="-1"
+>
+  <div
+    className="flex-parent"
+  >
+    <div
+      className="flex-child"
+    >
+      <div
+        className="channel-header__info"
+        id="channelHeaderInfo"
+      >
+        <div
+          className="channel-header__title dropdown"
+        >
+          <div>
+            <MenuWrapper
+              animationComponent={[Function]}
+              className=""
+            >
+              <div
+                className="channel-header__top"
+                id="channelHeaderDropdownButton"
+              >
+                <button
+                  aria-label="channel menu"
+                  className="channel-header__trigger style--none"
+                >
+                  <strong
+                    aria-level="2"
+                    className="heading"
+                    id="channelHeaderTitle"
+                    role="heading"
+                  >
+                    <span>
+                      <ArchiveIcon
+                        className="icon icon__archive icon channel-header-archived-icon svg-text-color"
+                      />
+                      <FormattedMessage
+                        defaultMessage="{displayname} (you) "
+                        id="channel_header.directchannel.you"
+                        values={
+                          Object {
+                            "displayname": undefined,
+                          }
+                        }
+                      />
+                      <GuestBadge
+                        className=""
+                        show={false}
+                      />
+                    </span>
+                  </strong>
+                  <span
+                    aria-label="dropdown icon"
+                    className="fa fa-angle-down header-dropdown__icon"
+                    id="channelHeaderDropdownIcon"
+                  />
+                </button>
+              </div>
+              <ChannelHeaderDropdown />
+            </MenuWrapper>
+          </div>
+        </div>
+        <div
+          className="channel-header__description"
+          id="channelHeaderDescription"
+        >
+          <StatusIcon
+            button={false}
+            className=""
+            status="offline"
+          />
+          <span
+            className="header-status__text"
+          >
+            <FormattedMessage
+              defaultMessage="Offline"
+              id="status_dropdown.set_offline"
+            />
+            <CustomStatusEmoji
+              emojiSize={15}
+              emojiStyle={
+                Object {
+                  "margin": "0 4px",
+                  "verticalAlign": "top",
+                }
+              }
+              showTooltip={false}
+              tooltipDirection="top"
+              userID="user_id"
+            />
+            In a meeting
+          </span>
+          <div
+            className="header-popover-text-measurer"
+          >
+            <Connect(Markdown)
+              message="not the bot description"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </div>
+          <span
+            className="header-description__text"
+            onClick={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            <Overlay
+              animation={[Function]}
+              onEnter={[Function]}
+              onHide={[Function]}
+              placement="bottom"
+              rootClose={true}
+              show={false}
+              target={null}
+            >
+              <Popover
+                className="channel-header__popover"
+                id="header-popover"
+                placement="bottom"
+                popoverSize="lg"
+                popoverStyle="info"
+                style={
+                  Object {
+                    "maxWidth": "0px",
+                    "transform": "translate(0px, 0px)",
+                  }
+                }
+              >
+                <span
+                  onClick={[Function]}
+                >
+                  <Connect(Markdown)
+                    message="not the bot description"
+                    options={
+                      Object {
+                        "atMentions": true,
+                        "channelNamesMap": undefined,
+                        "mentionHighlight": false,
+                        "singleline": false,
+                      }
+                    }
+                  />
+                </span>
+              </Popover>
+            </Overlay>
+            <Connect(Markdown)
+              message="not the bot description"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="flex-child"
+    />
+    <Connect(ChannelHeaderPlug)
+      channel={
+        Object {
+          "header": "not the bot description",
+          "status": "offline",
+          "type": "D",
+        }
+      }
+      channelMember={
+        Object {
+          "channel_id": "channel_id",
+          "user_id": "user_id",
+        }
+      }
+    />
+    <HeaderIconWrapper
+      ariaLabel={true}
+      buttonClass="channel-header__icon channel-header__icon--wide"
+      buttonId="channelHeaderPinButton"
+      iconComponent={
+        <PinIcon
+          aria-hidden="true"
+          className="icon icon--standard"
+        />
+      }
+      onClick={[Function]}
+      tooltipKey="pinnedPosts"
+    />
+    <HeaderIconWrapper
+      ariaLabel={true}
+      buttonId="channelHeaderSearchButton"
+      iconComponent={
+        <SearchIcon
+          aria-hidden="true"
+          className="icon icon--standard"
+        />
+      }
+      onClick={[Function]}
+      tooltipKey="search"
+    />
+    <HeaderIconWrapper
+      ariaLabel={true}
+      buttonClass="channel-header__icon"
+      buttonId="channelHeaderMentionButton"
+      iconComponent={
+        <MentionsIcon
+          aria-hidden="true"
+          className="icon icon--standard"
+        />
+      }
+      onClick={[Function]}
+      tooltipKey="recentMentions"
+    />
+    <HeaderIconWrapper
+      ariaLabel={true}
+      buttonClass="channel-header__icon"
+      buttonId="channelHeaderFlagButton"
+      iconComponent={
+        <FlagIcon
+          className="icon icon__flag"
+        />
+      }
+      onClick={[Function]}
+      tooltipKey="flaggedPosts"
+    />
+    <Connect(injectIntl(UserGuideDropdown)) />
+  </div>
+</div>
+`;
+
 exports[`components/ChannelHeader should render properly when empty 1`] = `
 <div
   className="channel-header"

--- a/components/channel_header/channel_header.test.jsx
+++ b/components/channel_header/channel_header.test.jsx
@@ -35,6 +35,7 @@ describe('components/ChannelHeader', () => {
         penultimateViewedChannelName: '',
         teammateNameDisplaySetting: '',
         currentRelativeTeamUrl: '',
+        isCustomStatusEnabled: false,
     };
 
     const populatedProps = {
@@ -238,5 +239,30 @@ describe('components/ChannelHeader', () => {
         expect(wrapper.containsMatchingElement(
             <GuestBadge show={true}/>,
         )).toEqual(true);
+    });
+
+    test('should render properly when custom status is set', () => {
+        const props = {
+            ...populatedProps,
+            channel: {
+                header: 'not the bot description',
+                type: Constants.DM_CHANNEL,
+                status: 'offline',
+            },
+            dmUser: {
+                id: 'user_id',
+                is_bot: false,
+            },
+            isCustomStatusEnabled: true,
+            customStatus: {
+                emoji: 'calender',
+                text: 'In a meeting',
+            },
+        };
+
+        const wrapper = shallowWithIntl(
+            <ChannelHeader {...props}/>,
+        );
+        expect(wrapper).toMatchSnapshot();
     });
 });

--- a/components/channel_header/index.js
+++ b/components/channel_header/index.js
@@ -60,7 +60,7 @@ function makeMapStateToProps() {
         if (channel && channel.type === General.DM_CHANNEL) {
             const dmUserId = getUserIdFromChannelName(user.id, channel.name);
             dmUser = getUser(state, dmUserId);
-            customStatus = getCustomStatus(state, dmUser.id);
+            customStatus = dmUser && getCustomStatus(state, dmUser.id);
         } else if (channel && channel.type === General.GM_CHANNEL) {
             gmMembers = doGetProfilesInChannel(state, channel.id, false);
         }

--- a/components/custom_status/__snapshots__/custom_status_emoji.test.tsx.snap
+++ b/components/custom_status/__snapshots__/custom_status_emoji.test.tsx.snap
@@ -41,3 +41,45 @@ exports[`components/custom_status/custom_status_emoji should match snapshot 1`] 
   />
 </ContextProvider>
 `;
+
+exports[`components/custom_status/custom_status_emoji should match snapshot with props 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "subscription": Subscription {
+        "handleChangeWrapper": [Function],
+        "listeners": Object {
+          "notify": [Function],
+        },
+        "onStateChange": [Function],
+        "parentSub": undefined,
+        "store": Object {
+          "clearActions": [Function],
+          "dispatch": [Function],
+          "getActions": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+        },
+        "unsubscribe": null,
+      },
+    }
+  }
+>
+  <CustomStatusEmoji
+    emojiSize={34}
+    emojiStyle={Object {}}
+    showTooltip={true}
+    tooltipDirection="bottom"
+    userID=""
+  />
+</ContextProvider>
+`;

--- a/components/custom_status/__snapshots__/custom_status_emoji.test.tsx.snap
+++ b/components/custom_status/__snapshots__/custom_status_emoji.test.tsx.snap
@@ -1,0 +1,85 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/custom_status/custom_status_emoji should match snapshot 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "subscription": Subscription {
+        "handleChangeWrapper": [Function],
+        "listeners": Object {
+          "notify": [Function],
+        },
+        "onStateChange": [Function],
+        "parentSub": undefined,
+        "store": Object {
+          "clearActions": [Function],
+          "dispatch": [Function],
+          "getActions": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+        },
+        "unsubscribe": null,
+      },
+    }
+  }
+>
+  <CustomStatusEmoji
+    emojiSize={16}
+    emojiStyle={Object {}}
+    showTooltip={false}
+    tooltipDirection="top"
+    userID=""
+  />
+</ContextProvider>
+`;
+
+exports[`components/custom_status/custom_status_emoji should match snapshot with props 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "subscription": Subscription {
+        "handleChangeWrapper": [Function],
+        "listeners": Object {
+          "notify": [Function],
+        },
+        "onStateChange": [Function],
+        "parentSub": undefined,
+        "store": Object {
+          "clearActions": [Function],
+          "dispatch": [Function],
+          "getActions": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+        },
+        "unsubscribe": null,
+      },
+    }
+  }
+>
+  <CustomStatusEmoji
+    emojiSize={34}
+    emojiStyle={Object {}}
+    showTooltip={true}
+    tooltipDirection="bottom"
+    userID=""
+  />
+</ContextProvider>
+`;

--- a/components/custom_status/__snapshots__/custom_status_emoji.test.tsx.snap
+++ b/components/custom_status/__snapshots__/custom_status_emoji.test.tsx.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/custom_status/custom_status_emoji should match snapshot 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "subscription": Subscription {
+        "handleChangeWrapper": [Function],
+        "listeners": Object {
+          "notify": [Function],
+        },
+        "onStateChange": [Function],
+        "parentSub": undefined,
+        "store": Object {
+          "clearActions": [Function],
+          "dispatch": [Function],
+          "getActions": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+        },
+        "unsubscribe": null,
+      },
+    }
+  }
+>
+  <CustomStatusEmoji
+    emojiSize={16}
+    emojiStyle={Object {}}
+    showTooltip={false}
+    tooltipDirection="top"
+    userID=""
+  />
+</ContextProvider>
+`;

--- a/components/custom_status/__snapshots__/custom_status_modal.test.tsx.snap
+++ b/components/custom_status/__snapshots__/custom_status_modal.test.tsx.snap
@@ -1,0 +1,77 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/custom_status/custom_status_modal should match snapshot 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "subscription": Subscription {
+        "handleChangeWrapper": [Function],
+        "listeners": Object {
+          "notify": [Function],
+        },
+        "onStateChange": [Function],
+        "parentSub": undefined,
+        "store": Object {
+          "clearActions": [Function],
+          "dispatch": [Function],
+          "getActions": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+        },
+        "unsubscribe": null,
+      },
+    }
+  }
+>
+  <CustomStatusModal
+    onHide={[MockFunction]}
+  />
+</ContextProvider>
+`;
+
+exports[`components/custom_status/custom_status_modal should match snapshot when user has custom status set 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "subscription": Subscription {
+        "handleChangeWrapper": [Function],
+        "listeners": Object {
+          "notify": [Function],
+        },
+        "onStateChange": [Function],
+        "parentSub": undefined,
+        "store": Object {
+          "clearActions": [Function],
+          "dispatch": [Function],
+          "getActions": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+        },
+        "unsubscribe": null,
+      },
+    }
+  }
+>
+  <CustomStatusModal
+    onHide={[MockFunction]}
+  />
+</ContextProvider>
+`;

--- a/components/custom_status/__snapshots__/custom_status_suggestion.test.tsx.snap
+++ b/components/custom_status/__snapshots__/custom_status_suggestion.test.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/custom_status/custom_status_emoji should match snapshot 1`] = `
+<div
+  className="statusSuggestion__row cursor--pointer a11y--active"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <div
+    className="statusSuggestion__icon"
+  >
+    <RenderEmoji
+      emoji=""
+      size={20}
+    />
+  </div>
+  <span
+    className="statusSuggestion__text"
+  />
+</div>
+`;

--- a/components/custom_status/custom_status_emoji.test.tsx
+++ b/components/custom_status/custom_status_emoji.test.tsx
@@ -1,9 +1,14 @@
-import { mount, shallow } from 'enzyme';
-import React from 'react'
-import CustomStatusEmoji from './custom_status_emoji';
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {mount, shallow} from 'enzyme';
+import React from 'react';
+
 import configureStore from 'redux-mock-store';
-import { Provider } from 'react-redux';
-import { getCustomStatus, isCustomStatusEnabled } from 'selectors/views/custom_status';
+import {Provider} from 'react-redux';
+
+import {getCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
+
+import CustomStatusEmoji from './custom_status_emoji';
 
 jest.mock('selectors/views/custom_status', () => {
     const original = jest.requireActual('selectors/views/custom_status');
@@ -11,8 +16,8 @@ jest.mock('selectors/views/custom_status', () => {
         ...original,
         isCustomStatusEnabled: jest.fn(),
         getCustomStatus: jest.fn(),
-    }
-})
+    };
+});
 
 describe('components/custom_status/custom_status_emoji', () => {
     const mockStore = configureStore();
@@ -21,33 +26,47 @@ describe('components/custom_status/custom_status_emoji', () => {
     it('should match snapshot', () => {
         const wrapper = shallow(
             <Provider store={store}>
-                <CustomStatusEmoji />
-            </Provider>
+                <CustomStatusEmoji/>
+            </Provider>,
         );
 
         expect(wrapper).toMatchSnapshot();
-    })
+    });
+
+    it('should match snapshot with props', () => {
+        const wrapper = shallow(
+            <Provider store={store}>
+                <CustomStatusEmoji
+                    emojiSize={34}
+                    showTooltip={true}
+                    tooltipDirection='bottom'
+                />
+            </Provider>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
 
     it('should not render when EnableCustomStatus in config is false', () => {
         isCustomStatusEnabled.mockReturnValue(false);
         const wrapper = mount(
             <Provider store={store}>
-                <CustomStatusEmoji />
-            </Provider>
+                <CustomStatusEmoji/>
+            </Provider>,
         );
 
         expect(wrapper.isEmptyRender()).toBeTruthy();
-    })
+    });
 
     it('should not render when getCustomStatus returns null', () => {
         isCustomStatusEnabled.mockReturnValue(true);
         getCustomStatus.mockReturnValue(null);
         const wrapper = mount(
             <Provider store={store}>
-                <CustomStatusEmoji />
-            </Provider>
+                <CustomStatusEmoji/>
+            </Provider>,
         );
 
         expect(wrapper.isEmptyRender()).toBeTruthy();
-    })
-})
+    });
+});

--- a/components/custom_status/custom_status_emoji.test.tsx
+++ b/components/custom_status/custom_status_emoji.test.tsx
@@ -1,0 +1,53 @@
+import { mount, shallow } from 'enzyme';
+import React from 'react'
+import CustomStatusEmoji from './custom_status_emoji';
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+import { getCustomStatus, isCustomStatusEnabled } from 'selectors/views/custom_status';
+
+jest.mock('selectors/views/custom_status', () => {
+    const original = jest.requireActual('selectors/views/custom_status');
+    return {
+        ...original,
+        isCustomStatusEnabled: jest.fn(),
+        getCustomStatus: jest.fn(),
+    }
+})
+
+describe('components/custom_status/custom_status_emoji', () => {
+    const mockStore = configureStore();
+    const store = mockStore({});
+
+    it('should match snapshot', () => {
+        const wrapper = shallow(
+            <Provider store={store}>
+                <CustomStatusEmoji />
+            </Provider>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    })
+
+    it('should not render when EnableCustomStatus in config is false', () => {
+        isCustomStatusEnabled.mockReturnValue(false);
+        const wrapper = mount(
+            <Provider store={store}>
+                <CustomStatusEmoji />
+            </Provider>
+        );
+
+        expect(wrapper.isEmptyRender()).toBeTruthy();
+    })
+
+    it('should not render when getCustomStatus returns null', () => {
+        isCustomStatusEnabled.mockReturnValue(true);
+        getCustomStatus.mockReturnValue(null);
+        const wrapper = mount(
+            <Provider store={store}>
+                <CustomStatusEmoji />
+            </Provider>
+        );
+
+        expect(wrapper.isEmptyRender()).toBeTruthy();
+    })
+})

--- a/components/custom_status/custom_status_emoji.test.tsx
+++ b/components/custom_status/custom_status_emoji.test.tsx
@@ -1,0 +1,72 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {mount, shallow} from 'enzyme';
+import React from 'react';
+
+import configureStore from 'redux-mock-store';
+import {Provider} from 'react-redux';
+
+import {getCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
+
+import CustomStatusEmoji from './custom_status_emoji';
+
+jest.mock('selectors/views/custom_status', () => {
+    const original = jest.requireActual('selectors/views/custom_status');
+    return {
+        ...original,
+        isCustomStatusEnabled: jest.fn(),
+        getCustomStatus: jest.fn(),
+    };
+});
+
+describe('components/custom_status/custom_status_emoji', () => {
+    const mockStore = configureStore();
+    const store = mockStore({});
+
+    it('should match snapshot', () => {
+        const wrapper = shallow(
+            <Provider store={store}>
+                <CustomStatusEmoji/>
+            </Provider>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should match snapshot with props', () => {
+        const wrapper = shallow(
+            <Provider store={store}>
+                <CustomStatusEmoji
+                    emojiSize={34}
+                    showTooltip={true}
+                    tooltipDirection='bottom'
+                />
+            </Provider>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should not render when EnableCustomStatus in config is false', () => {
+        isCustomStatusEnabled.mockReturnValue(false);
+        const wrapper = mount(
+            <Provider store={store}>
+                <CustomStatusEmoji/>
+            </Provider>,
+        );
+
+        expect(wrapper.isEmptyRender()).toBeTruthy();
+    });
+
+    it('should not render when getCustomStatus returns null', () => {
+        isCustomStatusEnabled.mockReturnValue(true);
+        getCustomStatus.mockReturnValue(null);
+        const wrapper = mount(
+            <Provider store={store}>
+                <CustomStatusEmoji/>
+            </Provider>,
+        );
+
+        expect(wrapper.isEmptyRender()).toBeTruthy();
+    });
+});

--- a/components/custom_status/custom_status_modal.test.tsx
+++ b/components/custom_status/custom_status_modal.test.tsx
@@ -1,0 +1,62 @@
+
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import React from 'react';
+import {shallow} from 'enzyme';
+import configureStore from 'redux-mock-store';
+import {Provider} from 'react-redux';
+
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+
+import {TestHelper} from 'utils/test_helper';
+
+import CustomStatusModal from './custom_status_modal';
+
+jest.mock('mattermost-redux/selectors/entities/users', () => {
+    const original = jest.requireActual('mattermost-redux/selectors/entities/users');
+    return {
+        ...original,
+        getCurrentUser: jest.fn(),
+    };
+});
+
+describe('components/custom_status/custom_status_modal', () => {
+    const mockStore = configureStore();
+    const store = mockStore({});
+    const baseProps = {
+        onHide: jest.fn(),
+    };
+    let user = TestHelper.getUserMock();
+
+    it('should match snapshot', () => {
+        const wrapper = shallow(
+            <Provider store={store}>
+                <CustomStatusModal {...baseProps}/>
+            </Provider>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should match snapshot when user has custom status set', () => {
+        const customStatus = {
+            emoji: 'speech_balloon',
+            text: 'speaking',
+        };
+        const recentCustomStatuses = [customStatus];
+        user = TestHelper.getUserMock({
+            props: {
+                customStatus: JSON.stringify(customStatus),
+                recentCustomStatuses: JSON.stringify(recentCustomStatuses),
+            },
+        });
+        getCurrentUser.mockReturnValue(user);
+        const wrapper = shallow(
+            <Provider store={store}>
+                <CustomStatusModal {...baseProps}/>
+            </Provider>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/components/custom_status/custom_status_modal.test.tsx
+++ b/components/custom_status/custom_status_modal.test.tsx
@@ -1,0 +1,63 @@
+
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import React from 'react';
+import {shallow} from 'enzyme';
+import configureStore from 'redux-mock-store';
+import {Provider} from 'react-redux';
+
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+
+import {TestHelper} from 'utils/test_helper';
+
+import CustomStatusModal from './custom_status_modal';
+
+jest.mock('mattermost-redux/selectors/entities/users', () => {
+    const original = jest.requireActual('mattermost-redux/selectors/entities/users');
+    return {
+        ...original,
+        getCurrentUser: jest.fn(),
+    };
+});
+
+describe('components/custom_status/custom_status_modal', () => {
+    const mockStore = configureStore();
+    const store = mockStore({});
+    const baseProps = {
+        onHide: jest.fn(),
+    };
+    let user = TestHelper.getUserMock();
+
+    it('should match snapshot', () => {
+        getCurrentUser.mockReturnValue(user);
+        const wrapper = shallow(
+            <Provider store={store}>
+                <CustomStatusModal {...baseProps}/>
+            </Provider>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should match snapshot when user has custom status set', () => {
+        const customStatus = {
+            emoji: 'speech_balloon',
+            text: 'speaking',
+        };
+        const recentCustomStatuses = [customStatus];
+        user = TestHelper.getUserMock({
+            props: {
+                customStatus: JSON.stringify(customStatus),
+                recentCustomStatuses: JSON.stringify(recentCustomStatuses),
+            },
+        });
+        getCurrentUser.mockReturnValue(user);
+        const wrapper = shallow(
+            <Provider store={store}>
+                <CustomStatusModal {...baseProps}/>
+            </Provider>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/components/custom_status/custom_status_modal.test.tsx
+++ b/components/custom_status/custom_status_modal.test.tsx
@@ -29,7 +29,6 @@ describe('components/custom_status/custom_status_modal', () => {
     let user = TestHelper.getUserMock();
 
     it('should match snapshot', () => {
-        getCurrentUser.mockReturnValue(user);
         const wrapper = shallow(
             <Provider store={store}>
                 <CustomStatusModal {...baseProps}/>

--- a/components/custom_status/custom_status_modal.tsx
+++ b/components/custom_status/custom_status_modal.tsx
@@ -1,13 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import React, {useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import classNames from 'classnames';
 import {FormattedMessage} from 'react-intl';
+import {setCustomStatus, unsetCustomStatus, removeRecentCustomStatus} from 'mattermost-redux/actions/users';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {Tooltip} from 'react-bootstrap';
 
-import {removeRecentCustomStatus, unsetUserCustomStatus, updateUserCustomStatus} from 'actions/views/custom_status';
 import GenericModal from 'components/generic_modal';
 import 'components/category_modal.scss';
 import EmojiIcon from 'components/widgets/icons/emoji_icon';
@@ -17,6 +17,9 @@ import {GlobalState} from 'types/store';
 import OverlayTrigger from 'components/overlay_trigger';
 import Constants from 'utils/constants';
 import RenderEmoji from 'components/emoji/render_emoji';
+
+import {showStatusDropdownPulsatingDot} from 'utils/custom_status';
+import {setCustomStatusInitialisationState} from 'actions/views/custom_status';
 
 import CustomStatusSuggestion from './custom_status_suggestion';
 
@@ -37,16 +40,26 @@ const CustomStatusModal: React.FC<Props> = (props: Props) => {
     const [text, setText] = useState<string>(currentCustomStatus.text);
     const [emoji, setEmoji] = useState<string>(currentCustomStatus.emoji);
     const isStatusSet = emoji || text;
+    const firstTimeModalOpened = useSelector((state: GlobalState) => showStatusDropdownPulsatingDot(state));
+
+    const handleCustomStatusInitializationState = () => {
+        if (firstTimeModalOpened) {
+            dispatch(setCustomStatusInitialisationState({hasOpenedSetCustomStatusModal: true}));
+        }
+    };
+
+    useEffect(handleCustomStatusInitializationState, []);
+
     const handleSetStatus = () => {
         const customStatus = {
             emoji: emoji || 'speech_balloon',
             text,
         };
-        dispatch(updateUserCustomStatus(customStatus));
+        dispatch(setCustomStatus(customStatus));
     };
 
     const handleClearStatus = () => {
-        dispatch(unsetUserCustomStatus());
+        dispatch(unsetCustomStatus());
     };
 
     const getCustomStatusControlRef = () => {

--- a/components/custom_status/custom_status_modal.tsx
+++ b/components/custom_status/custom_status_modal.tsx
@@ -4,10 +4,10 @@ import React, {useRef, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import classNames from 'classnames';
 import {FormattedMessage} from 'react-intl';
+import {setCustomStatus, unsetCustomStatus, removeRecentCustomStatus} from 'mattermost-redux/actions/users';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {Tooltip} from 'react-bootstrap';
 
-import {removeRecentCustomStatus, unsetUserCustomStatus, updateUserCustomStatus} from 'actions/views/custom_status';
 import GenericModal from 'components/generic_modal';
 import 'components/category_modal.scss';
 import EmojiIcon from 'components/widgets/icons/emoji_icon';
@@ -42,11 +42,11 @@ const CustomStatusModal: React.FC<Props> = (props: Props) => {
             emoji: emoji || 'speech_balloon',
             text,
         };
-        dispatch(updateUserCustomStatus(customStatus));
+        dispatch(setCustomStatus(customStatus));
     };
 
     const handleClearStatus = () => {
-        dispatch(unsetUserCustomStatus());
+        dispatch(unsetCustomStatus());
     };
 
     const getCustomStatusControlRef = () => {

--- a/components/custom_status/custom_status_modal.tsx
+++ b/components/custom_status/custom_status_modal.tsx
@@ -207,6 +207,7 @@ const CustomStatusModal: React.FC<Props> = (props: Props) => {
 
     return (
         <GenericModal
+            enforceFocus={false}
             onHide={props.onHide}
             modalHeaderText={
                 <FormattedMessage

--- a/components/custom_status/custom_status_modal.tsx
+++ b/components/custom_status/custom_status_modal.tsx
@@ -1,13 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import React, {useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import classNames from 'classnames';
 import {FormattedMessage} from 'react-intl';
+import {setCustomStatus, unsetCustomStatus, removeRecentCustomStatus} from 'mattermost-redux/actions/users';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {Tooltip} from 'react-bootstrap';
 
-import {removeRecentCustomStatus, unsetUserCustomStatus, updateUserCustomStatus} from 'actions/views/custom_status';
 import GenericModal from 'components/generic_modal';
 import 'components/category_modal.scss';
 import EmojiIcon from 'components/widgets/icons/emoji_icon';
@@ -17,6 +17,9 @@ import {GlobalState} from 'types/store';
 import OverlayTrigger from 'components/overlay_trigger';
 import Constants from 'utils/constants';
 import RenderEmoji from 'components/emoji/render_emoji';
+
+import {showCustomStatusPulsatingDotAndPostHeader} from 'utils/custom_status';
+import {setCustomStatusInitialisationState} from 'actions/views/custom_status';
 
 import CustomStatusSuggestion from './custom_status_suggestion';
 
@@ -37,16 +40,26 @@ const CustomStatusModal: React.FC<Props> = (props: Props) => {
     const [text, setText] = useState<string>(currentCustomStatus.text);
     const [emoji, setEmoji] = useState<string>(currentCustomStatus.emoji);
     const isStatusSet = emoji || text;
+    const firstTimeModalOpened = useSelector((state: GlobalState) => showCustomStatusPulsatingDotAndPostHeader(state));
+
+    const handleCustomStatusInitializationState = () => {
+        if (firstTimeModalOpened) {
+            dispatch(setCustomStatusInitialisationState({hasClickedSetStatusBefore: true}));
+        }
+    };
+
+    useEffect(handleCustomStatusInitializationState, []);
+
     const handleSetStatus = () => {
         const customStatus = {
             emoji: emoji || 'speech_balloon',
             text,
         };
-        dispatch(updateUserCustomStatus(customStatus));
+        dispatch(setCustomStatus(customStatus));
     };
 
     const handleClearStatus = () => {
-        dispatch(unsetUserCustomStatus());
+        dispatch(unsetCustomStatus());
     };
 
     const getCustomStatusControlRef = () => {
@@ -194,6 +207,7 @@ const CustomStatusModal: React.FC<Props> = (props: Props) => {
 
     return (
         <GenericModal
+            enforceFocus={false}
             onHide={props.onHide}
             modalHeaderText={
                 <FormattedMessage

--- a/components/custom_status/custom_status_modal.tsx
+++ b/components/custom_status/custom_status_modal.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import React, {useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import classNames from 'classnames';
 import {FormattedMessage} from 'react-intl';
@@ -17,6 +17,9 @@ import {GlobalState} from 'types/store';
 import OverlayTrigger from 'components/overlay_trigger';
 import Constants from 'utils/constants';
 import RenderEmoji from 'components/emoji/render_emoji';
+
+import {showCustomStatusPulsatingDotAndPostHeader} from 'utils/custom_status';
+import {setCustomStatusInitialisationState} from 'actions/views/custom_status';
 
 import CustomStatusSuggestion from './custom_status_suggestion';
 
@@ -37,6 +40,16 @@ const CustomStatusModal: React.FC<Props> = (props: Props) => {
     const [text, setText] = useState<string>(currentCustomStatus.text);
     const [emoji, setEmoji] = useState<string>(currentCustomStatus.emoji);
     const isStatusSet = emoji || text;
+    const firstTimeModalOpened = useSelector((state: GlobalState) => showCustomStatusPulsatingDotAndPostHeader(state));
+
+    const handleCustomStatusInitializationState = () => {
+        if (firstTimeModalOpened) {
+            dispatch(setCustomStatusInitialisationState({hasClickedSetStatusBefore: true}));
+        }
+    };
+
+    useEffect(handleCustomStatusInitializationState, []);
+
     const handleSetStatus = () => {
         const customStatus = {
             emoji: emoji || 'speech_balloon',

--- a/components/custom_status/custom_status_suggestion.test.tsx
+++ b/components/custom_status/custom_status_suggestion.test.tsx
@@ -1,0 +1,42 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {shallow} from 'enzyme';
+import React from 'react';
+
+import CustomStatusSuggestion from './custom_status_suggestion';
+
+describe('components/custom_status/custom_status_emoji', () => {
+    const baseProps = {
+        handleSuggestionClick: jest.fn(),
+        emoji: '',
+        text: '',
+        handleClear: jest.fn(),
+    };
+
+    it('should match snapshot', () => {
+        const wrapper = shallow(
+            <CustomStatusSuggestion {...baseProps}/>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should call handleSuggestionClick when click occurs on div', () => {
+        const wrapper = shallow(
+            <CustomStatusSuggestion {...baseProps}/>,
+        );
+
+        wrapper.find('.statusSuggestion__row').simulate('click');
+        expect(baseProps.handleSuggestionClick).toBeCalledTimes(1);
+    });
+
+    it('should render clearButton when hover occurs on div', () => {
+        const wrapper = shallow(
+            <CustomStatusSuggestion {...baseProps}/>,
+        );
+
+        expect(wrapper.find('.suggestion-clear').exists()).toBeFalsy();
+        wrapper.find('.statusSuggestion__row').simulate('mouseEnter');
+        expect(wrapper.find('.suggestion-clear').exists()).toBeTruthy();
+    });
+});

--- a/components/custom_status/custom_status_suggestion.test.tsx
+++ b/components/custom_status/custom_status_suggestion.test.tsx
@@ -1,0 +1,23 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {shallow} from 'enzyme';
+import React from 'react';
+
+import CustomStatusSuggestion from './custom_status_suggestion';
+
+describe('components/custom_status/custom_status_emoji', () => {
+    const baseProps = {
+        handleSuggestionClick: jest.fn(),
+        emoji: '',
+        text: '',
+        handleClear: jest.fn(),
+    };
+
+    it('should match snapshot', () => {
+        const wrapper = shallow(
+            <CustomStatusSuggestion {...baseProps}/>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/components/custom_status/custom_status_suggestion.test.tsx
+++ b/components/custom_status/custom_status_suggestion.test.tsx
@@ -20,4 +20,23 @@ describe('components/custom_status/custom_status_emoji', () => {
 
         expect(wrapper).toMatchSnapshot();
     });
+
+    it('should call handleSuggestionClick when click occurs on div', () => {
+        const wrapper = shallow(
+            <CustomStatusSuggestion {...baseProps}/>,
+        );
+
+        wrapper.find('.statusSuggestion__row').simulate('click');
+        expect(baseProps.handleSuggestionClick).toBeCalledTimes(1);
+    });
+
+    it('should render clearButton when hover occurs on div', () => {
+        const wrapper = shallow(
+            <CustomStatusSuggestion {...baseProps}/>,
+        );
+
+        expect(wrapper.find('.suggestion-clear').exists()).toBeFalsy();
+        wrapper.find('.statusSuggestion__row').simulate('mouseEnter');
+        expect(wrapper.find('.suggestion-clear').exists()).toBeTruthy();
+    });
 });

--- a/components/custom_status/custom_status_suggestion.tsx
+++ b/components/custom_status/custom_status_suggestion.tsx
@@ -3,18 +3,19 @@
 import React, {useState, useRef} from 'react';
 import {Tooltip} from 'react-bootstrap';
 
+import {UserCustomStatus} from 'mattermost-redux/types/users';
+
 import OverlayTrigger from 'components/overlay_trigger';
 import Constants from 'utils/constants';
-import {CustomStatus} from 'types/store/custom_status';
 import RenderEmoji from 'components/emoji/render_emoji';
 
 import './custom_status.scss';
 
 type Props = {
-    handleSuggestionClick: (status: CustomStatus) => void;
+    handleSuggestionClick: (status: UserCustomStatus) => void;
     emoji: string;
     text: string;
-    handleClear?: (status: CustomStatus) => void;
+    handleClear?: (status: UserCustomStatus) => void;
 };
 
 const CustomStatusSuggestion: React.FC<Props> = (props: Props) => {

--- a/components/emoji/render_emoji.tsx
+++ b/components/emoji/render_emoji.tsx
@@ -20,7 +20,11 @@ const RenderEmoji = ({emoji, emojiStyle = {}, size = 16}: ComponentProps) => {
     }
 
     const emojiMap = useSelector((state: GlobalState) => getEmojiMap(state));
-    const emojiImageUrl = getEmojiImageUrl(emojiMap.get(emoji));
+    const emojiFromMap = emojiMap.get(emoji);
+    if (!emojiFromMap) {
+        return null;
+    }
+    const emojiImageUrl = getEmojiImageUrl(emojiFromMap);
     return (
         <span
             className='emoticon'

--- a/components/generic_modal.tsx
+++ b/components/generic_modal.tsx
@@ -22,6 +22,7 @@ type Props = {
     id: string;
     autoCloseOnCancelButton?: boolean;
     autoCloseOnConfirmButton?: boolean;
+    enforceFocus?: boolean;
 };
 
 type State = {
@@ -34,6 +35,7 @@ export default class GenericModal extends React.PureComponent<Props, State> {
         id: 'genericModal',
         autoCloseOnCancelButton: true,
         autoCloseOnConfirmButton: true,
+        enforceFocus: true,
     };
 
     constructor(props: Props) {
@@ -124,7 +126,7 @@ export default class GenericModal extends React.PureComponent<Props, State> {
                 show={this.state.show}
                 onHide={this.onHide}
                 onExited={this.onHide}
-                enforceFocus={true}
+                enforceFocus={this.props.enforceFocus}
                 restoreFocus={true}
                 role='dialog'
                 aria-labelledby='genericModalLabel'

--- a/components/generic_modal.tsx
+++ b/components/generic_modal.tsx
@@ -124,7 +124,7 @@ export default class GenericModal extends React.PureComponent<Props, State> {
                 show={this.state.show}
                 onHide={this.onHide}
                 onExited={this.onHide}
-                enforceFocus={false}
+                enforceFocus={true}
                 restoreFocus={true}
                 role='dialog'
                 aria-labelledby='genericModalLabel'

--- a/components/generic_modal.tsx
+++ b/components/generic_modal.tsx
@@ -22,6 +22,7 @@ type Props = {
     id: string;
     autoCloseOnCancelButton?: boolean;
     autoCloseOnConfirmButton?: boolean;
+    enforceFocus?: boolean;
 };
 
 type State = {
@@ -34,6 +35,7 @@ export default class GenericModal extends React.PureComponent<Props, State> {
         id: 'genericModal',
         autoCloseOnCancelButton: true,
         autoCloseOnConfirmButton: true,
+        enforceFocus: true,
     };
 
     constructor(props: Props) {
@@ -124,7 +126,7 @@ export default class GenericModal extends React.PureComponent<Props, State> {
                 show={this.state.show}
                 onHide={this.onHide}
                 onExited={this.onHide}
-                enforceFocus={false}
+                enforceFocus={this.props.enforceFocus}
                 restoreFocus={true}
                 role='dialog'
                 aria-labelledby='genericModalLabel'

--- a/components/legacy_sidebar/sidebar_channel_button_or_link/__snapshots__/sidebar_channel_button_or_link.test.jsx.snap
+++ b/components/legacy_sidebar/sidebar_channel_button_or_link/__snapshots__/sidebar_channel_button_or_link.test.jsx.snap
@@ -24,6 +24,17 @@ exports[`component/legacy_sidebar/sidebar_channel_button_or_link/SidebarChannelB
       test-channel-name
     </span>
   </span>
+  <CustomStatusEmoji
+    emojiSize={16}
+    emojiStyle={
+      Object {
+        "marginLeft": 4,
+      }
+    }
+    showTooltip={true}
+    tooltipDirection="top"
+    userID="test-teammate-id"
+  />
   <SidebarChannelButtonOrLinkCloseButton
     badge={false}
     channelId="test-channel-id"
@@ -58,6 +69,17 @@ exports[`component/legacy_sidebar/sidebar_channel_button_or_link/SidebarChannelB
       test-channel-name
     </span>
   </span>
+  <CustomStatusEmoji
+    emojiSize={16}
+    emojiStyle={
+      Object {
+        "marginLeft": 4,
+      }
+    }
+    showTooltip={true}
+    tooltipDirection="top"
+    userID="test-teammate-id"
+  />
   <span
     className="badge"
     id="unreadMentions"
@@ -98,6 +120,17 @@ exports[`component/legacy_sidebar/sidebar_channel_button_or_link/SidebarChannelB
       test-channel-name
     </span>
   </span>
+  <CustomStatusEmoji
+    emojiSize={16}
+    emojiStyle={
+      Object {
+        "marginLeft": 4,
+      }
+    }
+    showTooltip={true}
+    tooltipDirection="top"
+    userID="test-teammate-id"
+  />
   <SidebarChannelButtonOrLinkCloseButton
     channelId="test-channel-id"
     channelType="D"
@@ -131,6 +164,17 @@ exports[`component/legacy_sidebar/sidebar_channel_button_or_link/SidebarChannelB
       test-channel-name
     </span>
   </span>
+  <CustomStatusEmoji
+    emojiSize={16}
+    emojiStyle={
+      Object {
+        "marginLeft": 4,
+      }
+    }
+    showTooltip={true}
+    tooltipDirection="top"
+    userID="test-teammate-id"
+  />
   <span
     className="badge"
     id="unreadMentions"
@@ -171,6 +215,17 @@ exports[`component/legacy_sidebar/sidebar_channel_button_or_link/SidebarChannelB
       test-channel-name
     </span>
   </span>
+  <CustomStatusEmoji
+    emojiSize={16}
+    emojiStyle={
+      Object {
+        "marginLeft": 4,
+      }
+    }
+    showTooltip={true}
+    tooltipDirection="top"
+    userID="test-teammate-id"
+  />
   <SidebarChannelButtonOrLinkCloseButton
     channelId="test-channel-id"
     channelType="D"

--- a/components/legacy_sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.test.jsx
+++ b/components/legacy_sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.test.jsx
@@ -134,4 +134,26 @@ describe('component/legacy_sidebar/sidebar_channel_button_or_link/SidebarChannel
             });
         }
     });
+
+    test('should enable tooltip when needed', () => {
+        const props = {
+            ...baseProps,
+            channelType: Constants.DM_CHANNEL,
+        };
+
+        const wrapper = shallow(
+            <SidebarChannelButtonOrLink {...props}/>,
+        );
+
+        const instance = wrapper.instance();
+        instance.displayNameRef = {
+            current: {
+                offsetWidth: 50,
+                scrollWidth: 60,
+            },
+        };
+
+        instance.enableToolTipIfNeeded();
+        expect(instance.state.showTooltip).toBe(true);
+    });
 });

--- a/components/more_direct_channels/__snapshots__/more_direct_channels.test.jsx.snap
+++ b/components/more_direct_channels/__snapshots__/more_direct_channels.test.jsx.snap
@@ -210,6 +210,17 @@ exports[`components/MoreDirectChannels should match renderOption snapshot 1`] = 
         className="badge-popoverlist"
         show={false}
       />
+      <CustomStatusEmoji
+        emojiSize={15}
+        emojiStyle={
+          Object {
+            "marginLeft": 4,
+          }
+        }
+        showTooltip={true}
+        tooltipDirection="top"
+        userID="user_id_1"
+      />
     </div>
     <div
       className="more-modal__description"

--- a/components/post_view/post/index.js
+++ b/components/post_view/post/index.js
@@ -4,19 +4,17 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
-import {Posts} from 'mattermost-redux/constants';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getPost, makeIsPostCommentMention} from 'mattermost-redux/selectors/entities/posts';
 import {get} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
 
 import {markPostAsUnread} from 'actions/post_actions';
 import {selectPost, selectPostCard} from 'actions/views/rhs';
 
 import {isArchivedChannel} from 'utils/channel_utils';
 import {Preferences} from 'utils/constants';
-import {makeCreateAriaLabelForPost, makeGetReplyCount} from 'utils/post_utils.jsx';
+import {areConsecutivePostsBySameUser, makeCreateAriaLabelForPost, makeGetReplyCount} from 'utils/post_utils.jsx';
 
 import Post from './post.jsx';
 
@@ -54,11 +52,7 @@ function makeMapStateToProps() {
         let previousPostIsComment = false;
 
         if (previousPost) {
-            consecutivePostByUser = post.user_id === previousPost.user_id && // The post is by the same user
-                post.create_at - previousPost.create_at <= Posts.POST_COLLAPSE_TIMEOUT && // And was within a short time period
-                !(post.props && post.props.from_webhook) && !(previousPost.props && previousPost.props.from_webhook) && // And neither is from a webhook
-                !isSystemMessage(post) && !isSystemMessage(previousPost); // And neither is a system message
-
+            consecutivePostByUser = areConsecutivePostsBySameUser(post, previousPost);
             previousPostIsComment = Boolean(previousPost.root_id);
         }
 

--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -86,6 +86,11 @@ class Post extends React.PureComponent {
         isLastPost: PropTypes.bool,
 
         /**
+         * To Check if the current post is last in the list by the current user
+         */
+        isCurrentUserLastPost: PropTypes.bool,
+
+        /**
          * Whether or not the channel that contains this post is archived
          */
         channelIsArchived: PropTypes.bool.isRequired,
@@ -403,6 +408,7 @@ class Post extends React.PureComponent {
                                 showTimeWithoutHover={!hideProfilePicture}
                                 hover={this.state.hover || this.state.a11yActive}
                                 isLastPost={this.props.isLastPost}
+                                isCurrentUserLastPost={this.props.isCurrentUserLastPost}
                             />
                             <PostBody
                                 post={post}

--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -88,7 +88,7 @@ class Post extends React.PureComponent {
         /**
          * To Check if the current post is last in the list by the current user
          */
-        isCurrentUserLastPost: PropTypes.bool,
+        isCurrentUserLastPostGroupFirstPost: PropTypes.bool,
 
         /**
          * Whether or not the channel that contains this post is archived
@@ -408,7 +408,7 @@ class Post extends React.PureComponent {
                                 showTimeWithoutHover={!hideProfilePicture}
                                 hover={this.state.hover || this.state.a11yActive}
                                 isLastPost={this.props.isLastPost}
-                                isCurrentUserLastPost={this.props.isCurrentUserLastPost}
+                                isCurrentUserLastPostGroupFirstPost={this.props.isCurrentUserLastPostGroupFirstPost}
                             />
                             <PostBody
                                 post={post}

--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -86,6 +86,11 @@ class Post extends React.PureComponent {
         isLastPost: PropTypes.bool,
 
         /**
+         * To Check if the current post is last in the list by the current user
+         */
+        isCurrentUserLastPostGroupFirstPost: PropTypes.bool,
+
+        /**
          * Whether or not the channel that contains this post is archived
          */
         channelIsArchived: PropTypes.bool.isRequired,
@@ -403,6 +408,7 @@ class Post extends React.PureComponent {
                                 showTimeWithoutHover={!hideProfilePicture}
                                 hover={this.state.hover || this.state.a11yActive}
                                 isLastPost={this.props.isLastPost}
+                                isCurrentUserLastPostGroupFirstPost={this.props.isCurrentUserLastPostGroupFirstPost}
                             />
                             <PostBody
                                 post={post}

--- a/components/post_view/post_header/__snapshots__/post_header.test.tsx.snap
+++ b/components/post_view/post_header/__snapshots__/post_header.test.tsx.snap
@@ -1,0 +1,197 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/post_view/post_header should match snapshot 1`] = `
+<div
+  className="post__header"
+>
+  <div
+    className="col col__name"
+  >
+    <Connect(UserProfile)
+      disablePopover={true}
+      overwriteImage={null}
+      overwriteName={
+        <FormattedMessage
+          defaultMessage="System"
+          id="post_info.system"
+        />
+      }
+    />
+  </div>
+  <div
+    className="col"
+  >
+    <Connect(PostInfo)
+      handleCardClick={[MockFunction]}
+      handleCommentClick={[MockFunction]}
+      handleDropdownOpened={[MockFunction]}
+      hover={false}
+      post={
+        Object {
+          "channel_id": "",
+          "create_at": 0,
+          "delete_at": 0,
+          "edit_at": 0,
+          "hashtags": "",
+          "id": "id",
+          "is_pinned": false,
+          "message": "post message",
+          "metadata": Object {
+            "embeds": Array [],
+            "emojis": Array [],
+            "files": Array [],
+            "images": Object {},
+            "reactions": Array [],
+          },
+          "original_id": "",
+          "parent_id": "",
+          "pending_post_id": "",
+          "props": Object {},
+          "reply_count": 0,
+          "root_id": "",
+          "type": "system_add_remove",
+          "update_at": 0,
+          "user_id": "user_id",
+        }
+      }
+      showTimeWithoutHover={false}
+    />
+  </div>
+</div>
+`;
+
+exports[`components/post_view/post_header should match snapshot when custom status is enabled and custom status is not set and post header link is enabled 1`] = `
+<div
+  className="post__header"
+>
+  <div
+    className="col col__name"
+  >
+    <Connect(UserProfile)
+      disablePopover={true}
+      overwriteImage={null}
+      overwriteName={
+        <FormattedMessage
+          defaultMessage="System"
+          id="post_info.system"
+        />
+      }
+    />
+    <div
+      className="post__header-set-custom-status cursor--pointer"
+      onClick={[Function]}
+    >
+      <EmojiIcon
+        className="post__header-set-custom-status-icon"
+      />
+      <span
+        className="post__header-set-custom-status-text"
+      >
+        <FormattedMessage
+          defaultMessage="Update your status"
+          id="post_header.update_status"
+        />
+      </span>
+    </div>
+  </div>
+  <div
+    className="col"
+  >
+    <Connect(PostInfo)
+      handleCardClick={[MockFunction]}
+      handleCommentClick={[MockFunction]}
+      handleDropdownOpened={[MockFunction]}
+      hover={false}
+      post={
+        Object {
+          "channel_id": "",
+          "create_at": 0,
+          "delete_at": 0,
+          "edit_at": 0,
+          "hashtags": "",
+          "id": "id",
+          "is_pinned": false,
+          "message": "post message",
+          "metadata": Object {
+            "embeds": Array [],
+            "emojis": Array [],
+            "files": Array [],
+            "images": Object {},
+            "reactions": Array [],
+          },
+          "original_id": "",
+          "parent_id": "",
+          "pending_post_id": "",
+          "props": Object {},
+          "reply_count": 0,
+          "root_id": "",
+          "type": "system_add_remove",
+          "update_at": 0,
+          "user_id": "user_id",
+        }
+      }
+      showTimeWithoutHover={false}
+    />
+  </div>
+</div>
+`;
+
+exports[`components/post_view/post_header should match snapshot when custom status is enabled and custom status is set 1`] = `
+<div
+  className="post__header"
+>
+  <div
+    className="col col__name"
+  >
+    <Connect(UserProfile)
+      disablePopover={true}
+      overwriteImage={null}
+      overwriteName={
+        <FormattedMessage
+          defaultMessage="System"
+          id="post_info.system"
+        />
+      }
+    />
+  </div>
+  <div
+    className="col"
+  >
+    <Connect(PostInfo)
+      handleCardClick={[MockFunction]}
+      handleCommentClick={[MockFunction]}
+      handleDropdownOpened={[MockFunction]}
+      hover={false}
+      post={
+        Object {
+          "channel_id": "",
+          "create_at": 0,
+          "delete_at": 0,
+          "edit_at": 0,
+          "hashtags": "",
+          "id": "id",
+          "is_pinned": false,
+          "message": "post message",
+          "metadata": Object {
+            "embeds": Array [],
+            "emojis": Array [],
+            "files": Array [],
+            "images": Object {},
+            "reactions": Array [],
+          },
+          "original_id": "",
+          "parent_id": "",
+          "pending_post_id": "",
+          "props": Object {},
+          "reply_count": 0,
+          "root_id": "",
+          "type": "system_add_remove",
+          "update_at": 0,
+          "user_id": "user_id",
+        }
+      }
+      showTimeWithoutHover={false}
+    />
+  </div>
+</div>
+`;

--- a/components/post_view/post_header/index.ts
+++ b/components/post_view/post_header/index.ts
@@ -14,8 +14,9 @@ import {GenericAction} from 'mattermost-redux/types/actions';
 import {GlobalState} from 'types/store';
 import {isGuest} from 'utils/utils.jsx';
 
-import {getCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
-import {openModal} from 'actions/views/modals';
+import {getCustomStatus, isCustomStatusEnabled, hasSetCustomStatusBefore, hasClickedOnUpdateStatusBefore} from 'selectors/views/custom_status';
+import {toggleStatusDropdown} from 'actions/views/status_dropdown';
+import {setFirstTimeUserProperties} from 'actions/views/custom_status';
 
 import PostHeader, {Props} from './post_header';
 
@@ -33,6 +34,7 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
     const user = getUser(state, ownProps.post.user_id);
     const currentUser = getCurrentUser(state);
     const customStatus = user ? getCustomStatus(state, user.id) : {};
+    const showUpdateStatusButton = !(hasSetCustomStatusBefore(state, currentUser.id) || hasClickedOnUpdateStatusBefore(state, currentUser.id));
     const isBot = Boolean(user && user.is_bot);
 
     return {
@@ -43,13 +45,15 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
         customStatus,
         currentUserID: currentUser.id,
         isCustomStatusEnabled: isCustomStatusEnabled(state),
+        showUpdateStatusButton,
     };
 }
 
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators({
-            openModal,
+            toggleStatusDropdown,
+            setFirstTimeUserProperties,
         }, dispatch),
     };
 }

--- a/components/post_view/post_header/index.ts
+++ b/components/post_view/post_header/index.ts
@@ -15,9 +15,8 @@ import {GlobalState} from 'types/store';
 import {isGuest} from 'utils/utils.jsx';
 
 import {getCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
-import {showUpdateStatusButton} from 'utils/custom_status';
+import {showCustomStatusLinkAndPulsatingDot} from 'utils/custom_status';
 import {setStatusDropdown} from 'actions/views/status_dropdown';
-import {setCustomStatusInitialisationState} from 'actions/views/custom_status';
 
 import PostHeader, {Props} from './post_header';
 
@@ -45,7 +44,7 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
         customStatus,
         currentUserID: currentUser.id,
         isCustomStatusEnabled: isCustomStatusEnabled(state),
-        showUpdateStatusButton: showUpdateStatusButton(state),
+        showUpdateStatusButton: showCustomStatusLinkAndPulsatingDot(state),
     };
 }
 
@@ -53,7 +52,6 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators({
             setStatusDropdown,
-            setCustomStatusInitialisationState,
         }, dispatch),
     };
 }

--- a/components/post_view/post_header/index.ts
+++ b/components/post_view/post_header/index.ts
@@ -15,7 +15,7 @@ import {GlobalState} from 'types/store';
 import {isGuest} from 'utils/utils.jsx';
 
 import {getCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
-import {showCustomStatusLinkAndPulsatingDot} from 'utils/custom_status';
+import {showCustomStatusPulsatingDotAndPostHeader} from 'utils/custom_status';
 import {setStatusDropdown} from 'actions/views/status_dropdown';
 
 import PostHeader, {Props} from './post_header';
@@ -44,7 +44,7 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
         customStatus,
         currentUserID: currentUser.id,
         isCustomStatusEnabled: isCustomStatusEnabled(state),
-        showUpdateStatusButton: showCustomStatusLinkAndPulsatingDot(state),
+        showUpdateStatusButton: showCustomStatusPulsatingDotAndPostHeader(state),
     };
 }
 

--- a/components/post_view/post_header/index.ts
+++ b/components/post_view/post_header/index.ts
@@ -14,9 +14,10 @@ import {GenericAction} from 'mattermost-redux/types/actions';
 import {GlobalState} from 'types/store';
 import {isGuest} from 'utils/utils.jsx';
 
-import {getCustomStatus, isCustomStatusEnabled, hasSetCustomStatusBefore, hasClickedOnUpdateStatusBefore} from 'selectors/views/custom_status';
-import {toggleStatusDropdown} from 'actions/views/status_dropdown';
-import {setFirstTimeUserProperties} from 'actions/views/custom_status';
+import {getCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
+import {showUpdateStatusButton} from 'utils/custom_status';
+import {setStatusDropdown} from 'actions/views/status_dropdown';
+import {setCustomStatusInitialProps} from 'actions/views/custom_status';
 
 import PostHeader, {Props} from './post_header';
 
@@ -34,7 +35,6 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
     const user = getUser(state, ownProps.post.user_id);
     const currentUser = getCurrentUser(state);
     const customStatus = user ? getCustomStatus(state, user.id) : {};
-    const showUpdateStatusButton = !(hasSetCustomStatusBefore(state, currentUser.id) || hasClickedOnUpdateStatusBefore(state, currentUser.id));
     const isBot = Boolean(user && user.is_bot);
 
     return {
@@ -45,15 +45,15 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
         customStatus,
         currentUserID: currentUser.id,
         isCustomStatusEnabled: isCustomStatusEnabled(state),
-        showUpdateStatusButton,
+        showUpdateStatusButton : showUpdateStatusButton(state),
     };
 }
 
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators({
-            toggleStatusDropdown,
-            setFirstTimeUserProperties,
+            setStatusDropdown,
+            setCustomStatusInitialProps,
         }, dispatch),
     };
 }

--- a/components/post_view/post_header/index.ts
+++ b/components/post_view/post_header/index.ts
@@ -45,7 +45,7 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
         customStatus,
         currentUserID: currentUser.id,
         isCustomStatusEnabled: isCustomStatusEnabled(state),
-        showUpdateStatusButton : showUpdateStatusButton(state),
+        showUpdateStatusButton: showUpdateStatusButton(state),
     };
 }
 

--- a/components/post_view/post_header/index.ts
+++ b/components/post_view/post_header/index.ts
@@ -15,9 +15,8 @@ import {GlobalState} from 'types/store';
 import {isGuest} from 'utils/utils.jsx';
 
 import {getCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
-import {showUpdateStatusButton} from 'utils/custom_status';
+import {showPostHeaderUpdateStatusButton} from 'utils/custom_status';
 import {setStatusDropdown} from 'actions/views/status_dropdown';
-import {setCustomStatusInitialisationState} from 'actions/views/custom_status';
 
 import PostHeader, {Props} from './post_header';
 
@@ -45,7 +44,7 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
         customStatus,
         currentUserID: currentUser.id,
         isCustomStatusEnabled: isCustomStatusEnabled(state),
-        showUpdateStatusButton: showUpdateStatusButton(state),
+        showUpdateStatusButton: showPostHeaderUpdateStatusButton(state),
     };
 }
 
@@ -53,7 +52,6 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators({
             setStatusDropdown,
-            setCustomStatusInitialisationState,
         }, dispatch),
     };
 }

--- a/components/post_view/post_header/index.ts
+++ b/components/post_view/post_header/index.ts
@@ -17,7 +17,7 @@ import {isGuest} from 'utils/utils.jsx';
 import {getCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
 import {showUpdateStatusButton} from 'utils/custom_status';
 import {setStatusDropdown} from 'actions/views/status_dropdown';
-import {setCustomStatusInitialProps} from 'actions/views/custom_status';
+import {setCustomStatusInitialisationState} from 'actions/views/custom_status';
 
 import PostHeader, {Props} from './post_header';
 
@@ -53,7 +53,7 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators({
             setStatusDropdown,
-            setCustomStatusInitialProps,
+            setCustomStatusInitialisationState,
         }, dispatch),
     };
 }

--- a/components/post_view/post_header/index.ts
+++ b/components/post_view/post_header/index.ts
@@ -15,7 +15,8 @@ import {GlobalState} from 'types/store';
 import {isGuest} from 'utils/utils.jsx';
 
 import {getCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
-import {openModal} from 'actions/views/modals';
+import {showCustomStatusPulsatingDotAndPostHeader} from 'utils/custom_status';
+import {setStatusDropdown} from 'actions/views/status_dropdown';
 
 import PostHeader, {Props} from './post_header';
 
@@ -43,13 +44,14 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
         customStatus,
         currentUserID: currentUser.id,
         isCustomStatusEnabled: isCustomStatusEnabled(state),
+        showUpdateStatusButton: showCustomStatusPulsatingDotAndPostHeader(state),
     };
 }
 
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators({
-            openModal,
+            setStatusDropdown,
         }, dispatch),
     };
 }

--- a/components/post_view/post_header/post_header.scss
+++ b/components/post_view/post_header/post_header.scss
@@ -5,23 +5,44 @@
 .post.other--root.current--user {
     .post__header-set-custom-status {
         display: revert;
-        background: #ecf3fd;
+        background: rgba(var(--center-channel-color-rgb), 0.08);
         padding: 0 4px;
         border-radius: 4px;
         margin-left: 8px;
+        
+        .post__header-set-custom-status-icon > svg {
+            height: 14px;
+            width: 14px;
+            vertical-align: middle;
+            background: inherit;
+            fill: rgba(var(--center-channel-color-rgb), 0.56);
+            margin-right: 4px;
+        }
+        .post__header-set-custom-status-text {
+            font-weight: normal;
+            font-size: 12px;
+            color: rgba(var(--center-channel-color-rgb), 0.56);
+        }
+    }
+    
+    .post__header-set-custom-status:hover {
+        .post__header-set-custom-status-icon > svg {
+            fill: rgba(var(--center-channel-color-rgb), 0.72);
+        }
+        .post__header-set-custom-status-text {
+            color: rgba(var(--center-channel-color-rgb), 0.72);
+        }
+    }
+    
+    .post__header-set-custom-status:active {
+        background: rgba(var(--button-bg-rgb), 0.08);
+        
+        .post__header-set-custom-status-icon > svg {
+            fill: var(--button-bg);
+        }
+        .post__header-set-custom-status-text {
+            color: var(--button-bg);
+        }
     }
 
-    .post__header-set-custom-status-icon > svg {
-        height: 14px;
-        width: 14px;
-        vertical-align: middle;
-        background: inherit;
-        fill: #3f76e6;
-        margin-right: 4px;
-    }
-    .post__header-set-custom-status-text {
-        font-weight: normal;
-        font-size: 12px;
-        color: #3f76e6;
-    }
 }

--- a/components/post_view/post_header/post_header.scss
+++ b/components/post_view/post_header/post_header.scss
@@ -1,0 +1,48 @@
+.post__header-set-custom-status {
+    display: none;
+}
+
+.post.other--root.current--user {
+    .post__header-set-custom-status {
+        display: revert;
+        background: rgba(var(--center-channel-color-rgb), 0.08);
+        padding: 0 4px;
+        border-radius: 4px;
+        margin-left: 8px;
+        
+        .post__header-set-custom-status-icon > svg {
+            height: 14px;
+            width: 14px;
+            vertical-align: middle;
+            background: inherit;
+            fill: rgba(var(--center-channel-color-rgb), 0.56);
+            margin-right: 4px;
+        }
+        .post__header-set-custom-status-text {
+            font-weight: normal;
+            font-size: 12px;
+            color: rgba(var(--center-channel-color-rgb), 0.56);
+        }
+    }
+    
+    .post__header-set-custom-status:hover {
+        .post__header-set-custom-status-icon > svg {
+            fill: rgba(var(--center-channel-color-rgb), 0.72);
+        }
+        .post__header-set-custom-status-text {
+            color: rgba(var(--center-channel-color-rgb), 0.72);
+        }
+    }
+    
+    .post__header-set-custom-status:active {
+        background: rgba(var(--button-bg-rgb), 0.08);
+        
+        .post__header-set-custom-status-icon > svg {
+            fill: var(--button-bg);
+        }
+        .post__header-set-custom-status-text {
+            color: var(--button-bg);
+        }
+    }
+
+}

--- a/components/post_view/post_header/post_header.scss
+++ b/components/post_view/post_header/post_header.scss
@@ -1,0 +1,27 @@
+.post__header-set-custom-status {
+    display: none;
+}
+
+.post.other--root.current--user {
+    .post__header-set-custom-status {
+        display: revert;
+        background: #ecf3fd;
+        padding: 0 4px;
+        border-radius: 4px;
+        margin-left: 8px;
+    }
+
+    .post__header-set-custom-status-icon > svg {
+        height: 14px;
+        width: 14px;
+        vertical-align: middle;
+        background: inherit;
+        fill: #3f76e6;
+        margin-right: 4px;
+    }
+    .post__header-set-custom-status-text {
+        font-weight: normal;
+        font-size: 12px;
+        color: #3f76e6;
+    }
+}

--- a/components/post_view/post_header/post_header.test.tsx
+++ b/components/post_view/post_header/post_header.test.tsx
@@ -1,0 +1,68 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {TestHelper} from 'utils/test_helper';
+
+import PostHeader from './post_header';
+
+describe('components/post_view/post_header', () => {
+    const post = TestHelper.getPostMock();
+    const baseProps = {
+        post,
+        handleCommentClick: jest.fn(),
+        handleCardClick: jest.fn(),
+        handleDropdownOpened: jest.fn(),
+        hover: false,
+        showTimeWithoutHover: false,
+        enablePostUsernameOverride: false,
+        isBot: false,
+        isGuest: false,
+        isCurrentUserLastPostGroupFirstPost: true,
+        customStatus: {
+            emoji: '',
+            text: '',
+        },
+        currentUserID: '',
+        isCustomStatusEnabled: false,
+        showUpdateStatusButton: false,
+        actions: {
+            setStatusDropdown: jest.fn(),
+        },
+    };
+
+    it('should match snapshot', () => {
+        const wrapper = shallow(
+            <PostHeader {...baseProps}/>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should match snapshot when custom status is enabled and custom status is set', () => {
+        const props = {
+            ...baseProps,
+            isCustomStatusEnabled: true,
+            customStatus: {emoji: 'calender', text: 'In a meeting'},
+        };
+        const wrapper = shallow(
+            <PostHeader {...props}/>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should match snapshot when custom status is enabled and custom status is not set and post header link is enabled', () => {
+        const props = {
+            ...baseProps,
+            isCustomStatusEnabled: true,
+            showUpdateStatusButton: true,
+        };
+        const wrapper = shallow(
+            <PostHeader {...props}/>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/components/post_view/post_header/post_header.tsx
+++ b/components/post_view/post_header/post_header.tsx
@@ -14,7 +14,7 @@ import BotBadge from 'components/widgets/badges/bot_badge';
 import Badge from 'components/widgets/badges/badge';
 import CustomStatusEmoji from 'components/custom_status/custom_status_emoji';
 import EmojiIcon from 'components/widgets/icons/emoji_icon';
-import {CustomStatus, CustomStatusInitialisationStates} from 'types/store/custom_status';
+import {CustomStatus} from 'types/store/custom_status';
 
 export type Props = {
 
@@ -108,14 +108,12 @@ export type Props = {
 
     actions: {
         setStatusDropdown: (open: boolean) => void;
-        setCustomStatusInitialisationState: (prop: Partial<CustomStatusInitialisationStates>) => void;
     };
 };
 
 export default class PostHeader extends React.PureComponent<Props> {
     updateStatus = () => {
         this.props.actions.setStatusDropdown(true);
-        this.props.actions.setCustomStatusInitialisationState({menuOpenedOnClick: Constants.CustomStatusInitialisationStates.MENU_OPENED_BY_POST_HEADER});
     }
 
     render(): JSX.Element {
@@ -215,7 +213,7 @@ export default class PostHeader extends React.PureComponent<Props> {
             );
         }
 
-        if (this.props.isCustomStatusEnabled && !isSystemMessage && isCurrentUser && !isCustomStatusSet) {
+        if (this.props.isCustomStatusEnabled && !isSystemMessage && isCurrentUser && !isCustomStatusSet && this.props.showUpdateStatusButton) {
             customStatus = (
                 <div
                     onClick={this.updateStatus}

--- a/components/post_view/post_header/post_header.tsx
+++ b/components/post_view/post_header/post_header.tsx
@@ -14,7 +14,7 @@ import BotBadge from 'components/widgets/badges/bot_badge';
 import Badge from 'components/widgets/badges/badge';
 import CustomStatusEmoji from 'components/custom_status/custom_status_emoji';
 import EmojiIcon from 'components/widgets/icons/emoji_icon';
-import {CustomStatus, CustomStatusInitialProps} from 'types/store/custom_status';
+import {CustomStatus, CustomStatusInitialisationState} from 'types/store/custom_status';
 
 export type Props = {
 
@@ -108,14 +108,14 @@ export type Props = {
 
     actions: {
         setStatusDropdown: (open: boolean) => void;
-        setCustomStatusInitialProps: (prop: Partial<CustomStatusInitialProps>) => void;
+        setCustomStatusInitialisationState: (prop: Partial<CustomStatusInitialisationState>) => void;
     };
 };
 
 export default class PostHeader extends React.PureComponent<Props> {
     updateStatus = () => {
         this.props.actions.setStatusDropdown(true);
-        this.props.actions.setCustomStatusInitialProps({menuOpenedOnClick: Constants.CustomStatusInitialProps.MENU_OPENED_BY_POST_HEADER});
+        this.props.actions.setCustomStatusInitialisationState({menuOpenedOnClick: Constants.CustomStatusInitialisationState.MENU_OPENED_BY_POST_HEADER});
     }
 
     render(): JSX.Element {

--- a/components/post_view/post_header/post_header.tsx
+++ b/components/post_view/post_header/post_header.tsx
@@ -14,7 +14,7 @@ import BotBadge from 'components/widgets/badges/bot_badge';
 import Badge from 'components/widgets/badges/badge';
 import CustomStatusEmoji from 'components/custom_status/custom_status_emoji';
 import EmojiIcon from 'components/widgets/icons/emoji_icon';
-import {CustomStatus, CustomStatusInitialisationState} from 'types/store/custom_status';
+import {CustomStatus, CustomStatusInitialisationStates} from 'types/store/custom_status';
 
 export type Props = {
 
@@ -86,7 +86,7 @@ export type Props = {
     /**
      * To Check if the current post is last in the list by the current user
      */
-    isCurrentUserLastPost?: boolean;
+    isCurrentUserLastPostGroupFirstPost?: boolean;
 
     /**
      * Source of image that should be override current user profile.
@@ -108,14 +108,14 @@ export type Props = {
 
     actions: {
         setStatusDropdown: (open: boolean) => void;
-        setCustomStatusInitialisationState: (prop: Partial<CustomStatusInitialisationState>) => void;
+        setCustomStatusInitialisationState: (prop: Partial<CustomStatusInitialisationStates>) => void;
     };
 };
 
 export default class PostHeader extends React.PureComponent<Props> {
     updateStatus = () => {
         this.props.actions.setStatusDropdown(true);
-        this.props.actions.setCustomStatusInitialisationState({menuOpenedOnClick: Constants.CustomStatusInitialisationState.MENU_OPENED_BY_POST_HEADER});
+        this.props.actions.setCustomStatusInitialisationState({menuOpenedOnClick: Constants.CustomStatusInitialisationStates.MENU_OPENED_BY_POST_HEADER});
     }
 
     render(): JSX.Element {
@@ -215,7 +215,7 @@ export default class PostHeader extends React.PureComponent<Props> {
             );
         }
 
-        if (this.props.isCustomStatusEnabled && !isSystemMessage && isCurrentUser && !isCustomStatusSet && this.props.isCurrentUserLastPost && this.props.showUpdateStatusButton) {
+        if (this.props.isCustomStatusEnabled && !isSystemMessage && isCurrentUser && !isCustomStatusSet && this.props.isCurrentUserLastPostGroupFirstPost && this.props.showUpdateStatusButton) {
             customStatus = (
                 <div
                     onClick={this.updateStatus}

--- a/components/post_view/post_header/post_header.tsx
+++ b/components/post_view/post_header/post_header.tsx
@@ -6,6 +6,8 @@ import {FormattedMessage} from 'react-intl';
 
 import {Post} from 'mattermost-redux/types/posts';
 
+import {UserCustomStatus} from 'mattermost-redux/types/users';
+
 import Constants from 'utils/constants';
 import * as PostUtils from 'utils/post_utils.jsx';
 import PostInfo from 'components/post_view/post_info';
@@ -14,7 +16,6 @@ import BotBadge from 'components/widgets/badges/bot_badge';
 import Badge from 'components/widgets/badges/badge';
 import CustomStatusEmoji from 'components/custom_status/custom_status_emoji';
 import EmojiIcon from 'components/widgets/icons/emoji_icon';
-import {CustomStatus} from 'types/store/custom_status';
 import './post_header.scss';
 
 export type Props = {
@@ -97,7 +98,7 @@ export type Props = {
     /**
      * Custom status of the user
      */
-    customStatus: CustomStatus;
+    customStatus: UserCustomStatus;
 
     /**
      * User id of logged in user.

--- a/components/post_view/post_header/post_header.tsx
+++ b/components/post_view/post_header/post_header.tsx
@@ -15,6 +15,7 @@ import Badge from 'components/widgets/badges/badge';
 import CustomStatusEmoji from 'components/custom_status/custom_status_emoji';
 import EmojiIcon from 'components/widgets/icons/emoji_icon';
 import {CustomStatus} from 'types/store/custom_status';
+import './post_header.scss';
 
 export type Props = {
 

--- a/components/post_view/post_header/post_header.tsx
+++ b/components/post_view/post_header/post_header.tsx
@@ -6,7 +6,9 @@ import {FormattedMessage} from 'react-intl';
 
 import {Post} from 'mattermost-redux/types/posts';
 
-import Constants, {ModalIdentifiers} from 'utils/constants';
+import {UserCustomStatus} from 'mattermost-redux/types/users';
+
+import Constants from 'utils/constants';
 import * as PostUtils from 'utils/post_utils.jsx';
 import PostInfo from 'components/post_view/post_info';
 import UserProfile from 'components/user_profile';
@@ -14,8 +16,7 @@ import BotBadge from 'components/widgets/badges/bot_badge';
 import Badge from 'components/widgets/badges/badge';
 import CustomStatusEmoji from 'components/custom_status/custom_status_emoji';
 import EmojiIcon from 'components/widgets/icons/emoji_icon';
-import CustomStatusModal from 'components/custom_status/custom_status_modal';
-import {CustomStatus} from 'types/store/custom_status';
+import './post_header.scss';
 
 export type Props = {
 
@@ -85,6 +86,11 @@ export type Props = {
     isLastPost?: boolean;
 
     /**
+     * To Check if the current post is last in the list by the current user
+     */
+    isCurrentUserLastPostGroupFirstPost?: boolean;
+
+    /**
      * Source of image that should be override current user profile.
      */
     overwriteIcon?: string;
@@ -92,7 +98,7 @@ export type Props = {
     /**
      * Custom status of the user
      */
-    customStatus: CustomStatus;
+    customStatus: UserCustomStatus;
 
     /**
      * User id of logged in user.
@@ -100,21 +106,16 @@ export type Props = {
     currentUserID: string;
 
     isCustomStatusEnabled: boolean;
+    showUpdateStatusButton: boolean;
 
     actions: {
-        openModal: (modalData: { modalId: string; dialogType: any; dialogProps?: any }) => void;
+        setStatusDropdown: (open: boolean) => void;
     };
 };
 
 export default class PostHeader extends React.PureComponent<Props> {
-    showCustomStatusModal = () => {
-        const customStatusInputModalData = {
-            modalId: ModalIdentifiers.CUSTOM_STATUS,
-            dialogType: CustomStatusModal,
-            dialogProps: {userId: this.props.currentUserID},
-        };
-
-        this.props.actions.openModal(customStatusInputModalData);
+    updateStatus = () => {
+        this.props.actions.setStatusDropdown(true);
     }
 
     render(): JSX.Element {
@@ -200,7 +201,6 @@ export default class PostHeader extends React.PureComponent<Props> {
 
         const userCustomStatus = this.props.customStatus;
         const isCustomStatusSet = userCustomStatus && userCustomStatus.emoji;
-        const isCurrentUser = this.props.post.user_id && this.props.post.user_id === this.props.currentUserID;
         if (this.props.isCustomStatusEnabled && !isSystemMessage && isCustomStatusSet) {
             customStatus = (
                 <CustomStatusEmoji
@@ -214,10 +214,10 @@ export default class PostHeader extends React.PureComponent<Props> {
             );
         }
 
-        if (this.props.isCustomStatusEnabled && !isSystemMessage && isCurrentUser && !isCustomStatusSet && this.props.isLastPost) {
+        if (this.props.isCustomStatusEnabled && !isCustomStatusSet && this.props.showUpdateStatusButton && this.props.isCurrentUserLastPostGroupFirstPost) {
             customStatus = (
                 <div
-                    onClick={this.showCustomStatusModal}
+                    onClick={this.updateStatus}
                     className='post__header-set-custom-status cursor--pointer'
                 >
                     <EmojiIcon className='post__header-set-custom-status-icon'/>

--- a/components/post_view/post_header/post_header.tsx
+++ b/components/post_view/post_header/post_header.tsx
@@ -200,7 +200,6 @@ export default class PostHeader extends React.PureComponent<Props> {
 
         const userCustomStatus = this.props.customStatus;
         const isCustomStatusSet = userCustomStatus && userCustomStatus.emoji;
-        const isCurrentUser = this.props.post.user_id && this.props.post.user_id === this.props.currentUserID;
         if (this.props.isCustomStatusEnabled && !isSystemMessage && isCustomStatusSet) {
             customStatus = (
                 <CustomStatusEmoji
@@ -214,7 +213,7 @@ export default class PostHeader extends React.PureComponent<Props> {
             );
         }
 
-        if (this.props.isCustomStatusEnabled && !isSystemMessage && isCurrentUser && !isCustomStatusSet && this.props.showUpdateStatusButton && this.props.isCurrentUserLastPostGroupFirstPost) {
+        if (this.props.isCustomStatusEnabled && !isCustomStatusSet && this.props.showUpdateStatusButton && this.props.isCurrentUserLastPostGroupFirstPost) {
             customStatus = (
                 <div
                     onClick={this.updateStatus}

--- a/components/post_view/post_header/post_header.tsx
+++ b/components/post_view/post_header/post_header.tsx
@@ -107,15 +107,15 @@ export type Props = {
     showUpdateStatusButton: boolean;
 
     actions: {
-        toggleStatusDropdown: (open: boolean) => void;
-        setFirstTimeUserProperties: (property: string) => void;
+        setStatusDropdown: (open: boolean) => void;
+        setCustomStatusInitialProps: (property: string) => void;
     };
 };
 
 export default class PostHeader extends React.PureComponent<Props> {
     updateStatus = () => {
-        this.props.actions.toggleStatusDropdown(true);
-        this.props.actions.setFirstTimeUserProperties(Constants.CustomStatusInitialProps.CLICK_ON_UPDATE_STATUS_FROM_POST);
+        this.props.actions.setStatusDropdown(true);
+        this.props.actions.setCustomStatusInitialProps(Constants.CustomStatusInitialProps.CLICK_ON_UPDATE_STATUS_FROM_POST);
     }
 
     render(): JSX.Element {

--- a/components/post_view/post_header/post_header.tsx
+++ b/components/post_view/post_header/post_header.tsx
@@ -6,7 +6,7 @@ import {FormattedMessage} from 'react-intl';
 
 import {Post} from 'mattermost-redux/types/posts';
 
-import Constants, {ModalIdentifiers} from 'utils/constants';
+import Constants from 'utils/constants';
 import * as PostUtils from 'utils/post_utils.jsx';
 import PostInfo from 'components/post_view/post_info';
 import UserProfile from 'components/user_profile';
@@ -14,7 +14,6 @@ import BotBadge from 'components/widgets/badges/bot_badge';
 import Badge from 'components/widgets/badges/badge';
 import CustomStatusEmoji from 'components/custom_status/custom_status_emoji';
 import EmojiIcon from 'components/widgets/icons/emoji_icon';
-import CustomStatusModal from 'components/custom_status/custom_status_modal';
 import {CustomStatus} from 'types/store/custom_status';
 
 export type Props = {
@@ -85,6 +84,11 @@ export type Props = {
     isLastPost?: boolean;
 
     /**
+     * To Check if the current post is last in the list by the current user
+     */
+    isCurrentUserLastPost?: boolean;
+
+    /**
      * Source of image that should be override current user profile.
      */
     overwriteIcon?: string;
@@ -100,21 +104,18 @@ export type Props = {
     currentUserID: string;
 
     isCustomStatusEnabled: boolean;
+    showUpdateStatusButton: boolean;
 
     actions: {
-        openModal: (modalData: { modalId: string; dialogType: any; dialogProps?: any }) => void;
+        toggleStatusDropdown: (open: boolean) => void;
+        setFirstTimeUserProperties: (property: string) => void;
     };
 };
 
 export default class PostHeader extends React.PureComponent<Props> {
-    showCustomStatusModal = () => {
-        const customStatusInputModalData = {
-            modalId: ModalIdentifiers.CUSTOM_STATUS,
-            dialogType: CustomStatusModal,
-            dialogProps: {userId: this.props.currentUserID},
-        };
-
-        this.props.actions.openModal(customStatusInputModalData);
+    updateStatus = () => {
+        this.props.actions.toggleStatusDropdown(true);
+        this.props.actions.setFirstTimeUserProperties(Constants.CustomStatusInitialProps.CLICK_ON_UPDATE_STATUS_FROM_POST);
     }
 
     render(): JSX.Element {
@@ -214,10 +215,10 @@ export default class PostHeader extends React.PureComponent<Props> {
             );
         }
 
-        if (this.props.isCustomStatusEnabled && !isSystemMessage && isCurrentUser && !isCustomStatusSet) {
+        if (this.props.isCustomStatusEnabled && !isSystemMessage && isCurrentUser && !isCustomStatusSet && this.props.isCurrentUserLastPost && this.props.showUpdateStatusButton) {
             customStatus = (
                 <div
-                    onClick={this.showCustomStatusModal}
+                    onClick={this.updateStatus}
                     className='post__header-set-custom-status cursor--pointer'
                 >
                     <EmojiIcon className='post__header-set-custom-status-icon'/>

--- a/components/post_view/post_header/post_header.tsx
+++ b/components/post_view/post_header/post_header.tsx
@@ -14,7 +14,7 @@ import BotBadge from 'components/widgets/badges/bot_badge';
 import Badge from 'components/widgets/badges/badge';
 import CustomStatusEmoji from 'components/custom_status/custom_status_emoji';
 import EmojiIcon from 'components/widgets/icons/emoji_icon';
-import {CustomStatus} from 'types/store/custom_status';
+import {CustomStatus, CustomStatusInitialProps} from 'types/store/custom_status';
 
 export type Props = {
 
@@ -108,14 +108,14 @@ export type Props = {
 
     actions: {
         setStatusDropdown: (open: boolean) => void;
-        setCustomStatusInitialProps: (property: string) => void;
+        setCustomStatusInitialProps: (prop: Partial<CustomStatusInitialProps>) => void;
     };
 };
 
 export default class PostHeader extends React.PureComponent<Props> {
     updateStatus = () => {
         this.props.actions.setStatusDropdown(true);
-        this.props.actions.setCustomStatusInitialProps(Constants.CustomStatusInitialProps.CLICK_ON_UPDATE_STATUS_FROM_POST);
+        this.props.actions.setCustomStatusInitialProps({menuOpenedOnClick: Constants.CustomStatusInitialProps.MENU_OPENED_BY_POST_HEADER});
     }
 
     render(): JSX.Element {

--- a/components/post_view/post_header/post_header.tsx
+++ b/components/post_view/post_header/post_header.tsx
@@ -214,7 +214,7 @@ export default class PostHeader extends React.PureComponent<Props> {
             );
         }
 
-        if (this.props.isCustomStatusEnabled && !isSystemMessage && isCurrentUser && !isCustomStatusSet && this.props.showUpdateStatusButton) {
+        if (this.props.isCustomStatusEnabled && !isSystemMessage && isCurrentUser && !isCustomStatusSet && this.props.showUpdateStatusButton && this.props.isCurrentUserLastPostGroupFirstPost) {
             customStatus = (
                 <div
                     onClick={this.updateStatus}

--- a/components/post_view/post_header/post_header.tsx
+++ b/components/post_view/post_header/post_header.tsx
@@ -6,6 +6,8 @@ import {FormattedMessage} from 'react-intl';
 
 import {Post} from 'mattermost-redux/types/posts';
 
+import {UserCustomStatus} from 'mattermost-redux/types/users';
+
 import Constants from 'utils/constants';
 import * as PostUtils from 'utils/post_utils.jsx';
 import PostInfo from 'components/post_view/post_info';
@@ -14,7 +16,7 @@ import BotBadge from 'components/widgets/badges/bot_badge';
 import Badge from 'components/widgets/badges/badge';
 import CustomStatusEmoji from 'components/custom_status/custom_status_emoji';
 import EmojiIcon from 'components/widgets/icons/emoji_icon';
-import {CustomStatus, CustomStatusInitialisationStates} from 'types/store/custom_status';
+import './post_header.scss';
 
 export type Props = {
 
@@ -96,7 +98,7 @@ export type Props = {
     /**
      * Custom status of the user
      */
-    customStatus: CustomStatus;
+    customStatus: UserCustomStatus;
 
     /**
      * User id of logged in user.
@@ -108,14 +110,12 @@ export type Props = {
 
     actions: {
         setStatusDropdown: (open: boolean) => void;
-        setCustomStatusInitialisationState: (prop: Partial<CustomStatusInitialisationStates>) => void;
     };
 };
 
 export default class PostHeader extends React.PureComponent<Props> {
     updateStatus = () => {
         this.props.actions.setStatusDropdown(true);
-        this.props.actions.setCustomStatusInitialisationState({menuOpenedOnClick: Constants.CustomStatusInitialisationStates.MENU_OPENED_BY_POST_HEADER});
     }
 
     render(): JSX.Element {
@@ -215,7 +215,7 @@ export default class PostHeader extends React.PureComponent<Props> {
             );
         }
 
-        if (this.props.isCustomStatusEnabled && !isSystemMessage && isCurrentUser && !isCustomStatusSet && this.props.isCurrentUserLastPostGroupFirstPost && this.props.showUpdateStatusButton) {
+        if (this.props.isCustomStatusEnabled && !isSystemMessage && isCurrentUser && !isCustomStatusSet && this.props.showUpdateStatusButton && this.props.isCurrentUserLastPostGroupFirstPost) {
             customStatus = (
                 <div
                     onClick={this.updateStatus}

--- a/components/post_view/post_header/post_header.tsx
+++ b/components/post_view/post_header/post_header.tsx
@@ -215,7 +215,7 @@ export default class PostHeader extends React.PureComponent<Props> {
             );
         }
 
-        if (this.props.isCustomStatusEnabled && !isSystemMessage && isCurrentUser && !isCustomStatusSet && this.props.isCurrentUserLastPostGroupFirstPost && this.props.showUpdateStatusButton) {
+        if (this.props.isCustomStatusEnabled && !isSystemMessage && isCurrentUser && !isCustomStatusSet) {
             customStatus = (
                 <div
                     onClick={this.updateStatus}

--- a/components/post_view/post_list/index.js
+++ b/components/post_view/post_list/index.js
@@ -12,7 +12,7 @@ import {makePreparePostIdsForPostList} from 'mattermost-redux/utils/post_list';
 import {RequestStatus} from 'mattermost-redux/constants';
 
 import {updateNewMessagesAtInChannel} from 'actions/global_actions';
-import {getLatestPostId, makeCreateAriaLabelForPost} from 'utils/post_utils.jsx';
+import {getLatestPostId, makeCreateAriaLabelForPost, getCurrentUserLastGroupedPostId} from 'utils/post_utils.jsx';
 import {
     checkAndSetMobileView,
     loadPosts,
@@ -64,6 +64,7 @@ function makeMapStateToProps() {
             atOldestPost = chunk.oldest;
         }
 
+        let currentUserLastPostId;
         if (postIds) {
             formattedPostIds = preparePostIdsForPostList(state, {postIds, lastViewedAt, indicateNewMessages: true, channelId});
             if (postIds.length) {
@@ -71,6 +72,7 @@ function makeMapStateToProps() {
                 const latestPost = getPost(state, latestPostId);
                 latestPostTimeStamp = latestPost.create_at;
                 latestAriaLabelFunc = createAriaLabelForPost(state, latestPost);
+                currentUserLastPostId = getCurrentUserLastGroupedPostId(state, postIds);
             }
         }
 
@@ -80,6 +82,7 @@ function makeMapStateToProps() {
             formattedPostIds,
             atLatestPost,
             atOldestPost,
+            currentUserLastPostId,
             latestPostTimeStamp,
             postListIds: postIds,
             latestAriaLabelFunc,

--- a/components/post_view/post_list/index.js
+++ b/components/post_view/post_list/index.js
@@ -12,7 +12,7 @@ import {makePreparePostIdsForPostList} from 'mattermost-redux/utils/post_list';
 import {RequestStatus} from 'mattermost-redux/constants';
 
 import {updateNewMessagesAtInChannel} from 'actions/global_actions';
-import {getLatestPostId, makeCreateAriaLabelForPost, getCurrentUserLastGroupedPostId} from 'utils/post_utils.jsx';
+import {getLatestPostId, makeCreateAriaLabelForPost, getCurrentUserLastPostGroupFirstPostId} from 'utils/post_utils.jsx';
 import {
     checkAndSetMobileView,
     loadPosts,
@@ -72,7 +72,7 @@ function makeMapStateToProps() {
                 const latestPost = getPost(state, latestPostId);
                 latestPostTimeStamp = latestPost.create_at;
                 latestAriaLabelFunc = createAriaLabelForPost(state, latestPost);
-                currentUserLastPostId = getCurrentUserLastGroupedPostId(state, postIds);
+                currentUserLastPostId = getCurrentUserLastPostGroupFirstPostId(state, postIds);
             }
         }
 

--- a/components/post_view/post_list/index.js
+++ b/components/post_view/post_list/index.js
@@ -12,7 +12,7 @@ import {makePreparePostIdsForPostList} from 'mattermost-redux/utils/post_list';
 import {RequestStatus} from 'mattermost-redux/constants';
 
 import {updateNewMessagesAtInChannel} from 'actions/global_actions';
-import {getLatestPostId, makeCreateAriaLabelForPost} from 'utils/post_utils.jsx';
+import {getLatestPostId, makeCreateAriaLabelForPost, getCurrentUserLastPostGroupFirstPostId} from 'utils/post_utils.jsx';
 import {
     checkAndSetMobileView,
     loadPosts,
@@ -64,6 +64,7 @@ function makeMapStateToProps() {
             atOldestPost = chunk.oldest;
         }
 
+        let currentUserLastPostId;
         if (postIds) {
             formattedPostIds = preparePostIdsForPostList(state, {postIds, lastViewedAt, indicateNewMessages: true, channelId});
             if (postIds.length) {
@@ -71,6 +72,7 @@ function makeMapStateToProps() {
                 const latestPost = getPost(state, latestPostId);
                 latestPostTimeStamp = latestPost.create_at;
                 latestAriaLabelFunc = createAriaLabelForPost(state, latestPost);
+                currentUserLastPostId = getCurrentUserLastPostGroupFirstPostId(state, postIds);
             }
         }
 
@@ -80,6 +82,7 @@ function makeMapStateToProps() {
             formattedPostIds,
             atLatestPost,
             atOldestPost,
+            currentUserLastPostId,
             latestPostTimeStamp,
             postListIds: postIds,
             latestAriaLabelFunc,

--- a/components/post_view/post_list/post_list.jsx
+++ b/components/post_view/post_list/post_list.jsx
@@ -82,6 +82,11 @@ export default class PostList extends React.PureComponent {
          */
         isPrefetchingInProcess: PropTypes.bool.isRequired,
 
+        /**
+         * Used for showing the Update custom status button on the post header
+         */
+        currentUserLastPostId: PropTypes.string,
+
         actions: PropTypes.shape({
 
             /*
@@ -321,6 +326,7 @@ export default class PostList extends React.PureComponent {
                             latestPostTimeStamp={this.props.latestPostTimeStamp}
                             latestAriaLabelFunc={this.props.latestAriaLabelFunc}
                             latestPostId={this.props.latestPostId}
+                            currentUserLastPostId={this.props.currentUserLastPostId}
                         />
                     </div>
                 </div>

--- a/components/post_view/post_list_row/__snapshots__/post_list_row.test.tsx.snap
+++ b/components/post_view/post_list_row/__snapshots__/post_list_row.test.tsx.snap
@@ -45,6 +45,7 @@ exports[`components/post_view/post_list_row should render channel intro message 
 exports[`components/post_view/post_list_row should render combined post 1`] = `
 <Connect(Connect(injectIntl(Post)))
   combinedId="user-activity-1234-5678"
+  isCurrentUserLastPostGroupFirstPost={false}
   isLastPost={false}
   previousPostId="abcd"
   shouldHighlight={false}
@@ -99,6 +100,7 @@ exports[`components/post_view/post_list_row should render new messages line 1`] 
 
 exports[`components/post_view/post_list_row should render post 1`] = `
 <Connect(injectIntl(Post))
+  isCurrentUserLastPostGroupFirstPost={false}
   isLastPost={false}
   postId="1234"
   previousPostId="abcd"

--- a/components/post_view/post_list_row/post_list_row.test.tsx
+++ b/components/post_view/post_list_row/post_list_row.test.tsx
@@ -28,6 +28,7 @@ describe('components/post_view/post_list_row', () => {
         shortcutReactToLastPostEmittedFrom: 'NO_WHERE',
         loadingNewerPosts: false,
         loadingOlderPosts: false,
+        isCurrentUserLastPostGroupFirstPost: false,
         actions: {
             emitShortcutReactToLastPostFrom: jest.fn(),
         },

--- a/components/post_view/post_list_row/post_list_row.tsx
+++ b/components/post_view/post_list_row/post_list_row.tsx
@@ -33,6 +33,11 @@ export type PostListRowProps = {
     isLastPost: boolean;
 
     /**
+     * To Check if the current post is last in the list by the current user
+     */
+    isCurrentUserLastPostGroupFirstPost: boolean;
+
+    /**
      * To check if the state of emoji for last message and from where it was emitted
      */
     shortcutReactToLastPostEmittedFrom: string;
@@ -145,6 +150,7 @@ export default class PostListRow extends React.PureComponent<PostListRowProps> {
             shouldHighlight: this.props.shouldHighlight,
             togglePostMenu: this.props.togglePostMenu,
             isLastPost: this.props.isLastPost,
+            isCurrentUserLastPostGroupFirstPost: this.props.isCurrentUserLastPostGroupFirstPost,
         };
 
         if (PostListUtils.isCombinedUserActivityPost(listId)) {

--- a/components/post_view/post_list_row/post_list_row.tsx
+++ b/components/post_view/post_list_row/post_list_row.tsx
@@ -35,7 +35,7 @@ export type PostListRowProps = {
     /**
      * To Check if the current post is last in the list by the current user
      */
-    isCurrentUserLastPost: boolean;
+    isCurrentUserLastPostGroupFirstPost: boolean;
 
     /**
      * To check if the state of emoji for last message and from where it was emitted
@@ -150,7 +150,7 @@ export default class PostListRow extends React.PureComponent<PostListRowProps> {
             shouldHighlight: this.props.shouldHighlight,
             togglePostMenu: this.props.togglePostMenu,
             isLastPost: this.props.isLastPost,
-            isCurrentUserLastPost: this.props.isCurrentUserLastPost,
+            isCurrentUserLastPostGroupFirstPost: this.props.isCurrentUserLastPostGroupFirstPost,
         };
 
         if (PostListUtils.isCombinedUserActivityPost(listId)) {

--- a/components/post_view/post_list_row/post_list_row.tsx
+++ b/components/post_view/post_list_row/post_list_row.tsx
@@ -33,6 +33,11 @@ export type PostListRowProps = {
     isLastPost: boolean;
 
     /**
+     * To Check if the current post is last in the list by the current user
+     */
+    isCurrentUserLastPost: boolean;
+
+    /**
      * To check if the state of emoji for last message and from where it was emitted
      */
     shortcutReactToLastPostEmittedFrom: string;
@@ -145,6 +150,7 @@ export default class PostListRow extends React.PureComponent<PostListRowProps> {
             shouldHighlight: this.props.shouldHighlight,
             togglePostMenu: this.props.togglePostMenu,
             isLastPost: this.props.isLastPost,
+            isCurrentUserLastPost: this.props.isCurrentUserLastPost,
         };
 
         if (PostListUtils.isCombinedUserActivityPost(listId)) {

--- a/components/post_view/post_list_virtualized/post_list_virtualized.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.jsx
@@ -310,7 +310,7 @@ class PostList extends React.PureComponent {
 
         // Since the first in the list is the latest message
         const isLastPost = itemId === this.state.postListIds[0];
-        const isCurrentUserLastPost = itemId === this.props.currentUserLastPostId;
+        const isCurrentUserLastPostGroupFirstPost = itemId === this.props.currentUserLastPostId;
 
         return (
             <div
@@ -325,7 +325,7 @@ class PostList extends React.PureComponent {
                     loadNewerPosts={this.props.actions.loadNewerPosts}
                     togglePostMenu={this.togglePostMenu}
                     isLastPost={isLastPost}
-                    isCurrentUserLastPost={isCurrentUserLastPost}
+                    isCurrentUserLastPostGroupFirstPost={isCurrentUserLastPostGroupFirstPost}
                     loadingNewerPosts={this.props.loadingNewerPosts}
                     loadingOlderPosts={this.props.loadingOlderPosts}
                 />

--- a/components/post_view/post_list_virtualized/post_list_virtualized.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.jsx
@@ -84,6 +84,11 @@ class PostList extends React.PureComponent {
         loadingNewerPosts: PropTypes.bool,
         loadingOlderPosts: PropTypes.bool,
 
+        /**
+         * Used for showing the Update custom status button on the post header
+         */
+        currentUserLastPostId: PropTypes.string,
+
         intl: intlShape.isRequired,
 
         latestPostTimeStamp: PropTypes.number,
@@ -305,6 +310,7 @@ class PostList extends React.PureComponent {
 
         // Since the first in the list is the latest message
         const isLastPost = itemId === this.state.postListIds[0];
+        const isCurrentUserLastPost = itemId === this.props.currentUserLastPostId;
 
         return (
             <div
@@ -319,6 +325,7 @@ class PostList extends React.PureComponent {
                     loadNewerPosts={this.props.actions.loadNewerPosts}
                     togglePostMenu={this.togglePostMenu}
                     isLastPost={isLastPost}
+                    isCurrentUserLastPost={isCurrentUserLastPost}
                     loadingNewerPosts={this.props.loadingNewerPosts}
                     loadingOlderPosts={this.props.loadingOlderPosts}
                 />

--- a/components/post_view/post_list_virtualized/post_list_virtualized.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.jsx
@@ -84,6 +84,11 @@ class PostList extends React.PureComponent {
         loadingNewerPosts: PropTypes.bool,
         loadingOlderPosts: PropTypes.bool,
 
+        /**
+         * Used for showing the Update custom status button on the post header
+         */
+        currentUserLastPostId: PropTypes.string,
+
         intl: intlShape.isRequired,
 
         latestPostTimeStamp: PropTypes.number,
@@ -305,6 +310,7 @@ class PostList extends React.PureComponent {
 
         // Since the first in the list is the latest message
         const isLastPost = itemId === this.state.postListIds[0];
+        const isCurrentUserLastPostGroupFirstPost = itemId === this.props.currentUserLastPostId;
 
         return (
             <div
@@ -319,6 +325,7 @@ class PostList extends React.PureComponent {
                     loadNewerPosts={this.props.actions.loadNewerPosts}
                     togglePostMenu={this.togglePostMenu}
                     isLastPost={isLastPost}
+                    isCurrentUserLastPostGroupFirstPost={isCurrentUserLastPostGroupFirstPost}
                     loadingNewerPosts={this.props.loadingNewerPosts}
                     loadingOlderPosts={this.props.loadingOlderPosts}
                 />

--- a/components/profile_popover/__snapshots__/profile_popover.test.jsx.snap
+++ b/components/profile_popover/__snapshots__/profile_popover.test.jsx.snap
@@ -2,7 +2,9 @@
 
 exports[`components/ProfilePopover should hide add-to-channel option if not on team 1`] = `
 <Popover
+  customStatus={Object {}}
   id="user-profile-popover"
+  isCustomStatusEnabled={true}
   isInCurrentTeam={false}
   placement="right"
   popoverSize="sm"
@@ -79,7 +81,134 @@ exports[`components/ProfilePopover should hide add-to-channel option if not on t
 
 exports[`components/ProfilePopover should match snapshot 1`] = `
 <Popover
+  customStatus={Object {}}
   id="user-profile-popover"
+  isCustomStatusEnabled={true}
+  isInCurrentTeam={true}
+  placement="right"
+  popoverSize="sm"
+  popoverStyle="info"
+  title={
+    <span
+      data-testid="profilePopoverTitle_some_username"
+    >
+      <span
+        className="user-popover__username"
+      >
+        @some_username
+      </span>
+    </span>
+  }
+>
+  <Memo(Avatar)
+    key="user-popover-image"
+    size="xxl"
+    url="src"
+    username="some_username"
+  />
+  <Connect(Pluggable)
+    hide={[MockFunction]}
+    key="profilePopoverPluggable2"
+    pluggableName="PopoverUserAttributes"
+    status="offline"
+    user={
+      Object {
+        "name": "some name",
+        "username": "some_username",
+      }
+    }
+  />
+  <div
+    className="popover__row first"
+    data-toggle="tooltip"
+    key="user-popover-dm"
+  >
+    <a
+      className="text-nowrap user-popover__email"
+      href="#"
+      onClick={[Function]}
+    >
+      <LocalizedIcon
+        className="fa fa-paper-plane"
+        title={
+          Object {
+            "defaultMessage": "Send Message Icon",
+            "id": "user_profile.send.dm.icon",
+          }
+        }
+      />
+      <FormattedMessage
+        defaultMessage="Send Message"
+        id="user_profile.send.dm"
+      />
+    </a>
+  </div>
+  <div
+    className="popover__row first"
+    data-toggle="tooltip"
+    key="user-popover-add-to-channel"
+  >
+    <a
+      className="text-nowrap"
+      href="#"
+      onClick={[Function]}
+    >
+      <Connect(injectIntl(ModalToggleButtonRedux))
+        accessibilityLabel="Add to a Channel"
+        dialogProps={
+          Object {
+            "user": Object {
+              "name": "some name",
+              "username": "some_username",
+            },
+          }
+        }
+        dialogType={
+          Object {
+            "$$typeof": Symbol(react.memo),
+            "WrappedComponent": [Function],
+            "compare": null,
+            "displayName": "Connect(AddUserToChannelModal)",
+            "type": [Function],
+          }
+        }
+        modalId="add_user_to_channel"
+        onClick={[MockFunction]}
+        role="menuitem"
+      >
+        <LocalizedIcon
+          className="fa fa-user-plus"
+          title={
+            Object {
+              "defaultMessage": "Add User to Channel Icon",
+              "id": "user_profile.add_user_to_channel.icon",
+            }
+          }
+        />
+        Add to a Channel
+      </Connect(injectIntl(ModalToggleButtonRedux))>
+    </a>
+  </div>
+  <Connect(Pluggable)
+    hide={[MockFunction]}
+    key="profilePopoverPluggable3"
+    pluggableName="PopoverUserActions"
+    status="offline"
+    user={
+      Object {
+        "name": "some name",
+        "username": "some_username",
+      }
+    }
+  />
+</Popover>
+`;
+
+exports[`components/ProfilePopover should match snapshot when tooltip is enabled 1`] = `
+<Popover
+  customStatus={Object {}}
+  id="user-profile-popover"
+  isCustomStatusEnabled={true}
   isInCurrentTeam={true}
   placement="right"
   popoverSize="sm"

--- a/components/profile_popover/index.js
+++ b/components/profile_popover/index.js
@@ -19,6 +19,7 @@ import {
 import {openDirectChannelToUserId} from 'actions/channel_actions.jsx';
 import {getMembershipForCurrentEntities} from 'actions/views/profile_popover';
 import {closeModal, openModal} from 'actions/views/modals';
+import {setCustomStatusInitialisationState} from 'actions/views/custom_status';
 
 import {areTimezonesEnabledAndSupported} from 'selectors/general';
 import {getSelectedPost, getRhsState} from 'selectors/rhs';
@@ -77,6 +78,7 @@ function mapDispatchToProps(dispatch) {
             openDirectChannelToUserId,
             openModal,
             getMembershipForCurrentEntities,
+            setCustomStatusInitialisationState,
         }, dispatch),
     };
 }

--- a/components/profile_popover/index.js
+++ b/components/profile_popover/index.js
@@ -19,7 +19,6 @@ import {
 import {openDirectChannelToUserId} from 'actions/channel_actions.jsx';
 import {getMembershipForCurrentEntities} from 'actions/views/profile_popover';
 import {closeModal, openModal} from 'actions/views/modals';
-import {setCustomStatusInitialisationState} from 'actions/views/custom_status';
 
 import {areTimezonesEnabledAndSupported} from 'selectors/general';
 import {getSelectedPost, getRhsState} from 'selectors/rhs';
@@ -78,7 +77,6 @@ function mapDispatchToProps(dispatch) {
             openDirectChannelToUserId,
             openModal,
             getMembershipForCurrentEntities,
-            setCustomStatusInitialisationState,
         }, dispatch),
     };
 }

--- a/components/profile_popover/profile_popover.jsx
+++ b/components/profile_popover/profile_popover.jsx
@@ -129,7 +129,6 @@ class ProfilePopover extends React.PureComponent {
             openDirectChannelToUserId: PropTypes.func.isRequired,
             openModal: PropTypes.func.isRequired,
             closeModal: PropTypes.func.isRequired,
-            setCustomStatusInitialisationState: PropTypes.func.isRequired,
         }).isRequired,
 
         /**
@@ -240,7 +239,6 @@ class ProfilePopover extends React.PureComponent {
         };
 
         this.props.actions.openModal(customStatusInputModalData);
-        this.props.actions.setCustomStatusInitialisationState({hasClickedSetStatusBefore: true});
     }
 
     handleAddToChannel = (e) => {

--- a/components/profile_popover/profile_popover.jsx
+++ b/components/profile_popover/profile_popover.jsx
@@ -151,7 +151,7 @@ class ProfilePopover extends React.PureComponent {
         this.customStatusTextRef = React.createRef();
         this.state = {
             loadingDMChannel: -1,
-            showTooltip: false,
+            showCustomStatusTooltip: false,
         };
     }
 
@@ -163,9 +163,9 @@ class ProfilePopover extends React.PureComponent {
     showCustomStatusTextTooltip = () => {
         const element = this.customStatusTextRef.current;
         if (element && element.offsetWidth < element.scrollWidth) {
-            this.setState({showTooltip: true});
+            this.setState({showCustomStatusTooltip: true});
         } else {
-            this.setState({showTooltip: false});
+            this.setState({showCustomStatusTooltip: false});
         }
     }
 
@@ -439,7 +439,7 @@ class ProfilePopover extends React.PureComponent {
                         {customStatus.text}
                     </div>
                 );
-                if (this.state.showTooltip) {
+                if (this.state.showCustomStatusTooltip) {
                     customStatusText = (
                         <OverlayTrigger
                             delayShow={Constants.OVERLAY_TIME_DELAY}

--- a/components/profile_popover/profile_popover.jsx
+++ b/components/profile_popover/profile_popover.jsx
@@ -129,6 +129,7 @@ class ProfilePopover extends React.PureComponent {
             openDirectChannelToUserId: PropTypes.func.isRequired,
             openModal: PropTypes.func.isRequired,
             closeModal: PropTypes.func.isRequired,
+            setCustomStatusInitialisationState: PropTypes.func.isRequired,
         }).isRequired,
 
         /**
@@ -239,6 +240,7 @@ class ProfilePopover extends React.PureComponent {
         };
 
         this.props.actions.openModal(customStatusInputModalData);
+        this.props.actions.setCustomStatusInitialisationState({hasClickedSetStatusBefore: true});
     }
 
     handleAddToChannel = (e) => {

--- a/components/profile_popover/profile_popover.test.jsx
+++ b/components/profile_popover/profile_popover.test.jsx
@@ -29,7 +29,6 @@ describe('components/ProfilePopover', () => {
             openModal: jest.fn(),
             closeModal: jest.fn(),
             loadBot: jest.fn(),
-            setCustomStatusInitialisationState: jest.fn(),
         },
     };
 

--- a/components/profile_popover/profile_popover.test.jsx
+++ b/components/profile_popover/profile_popover.test.jsx
@@ -28,6 +28,7 @@ describe('components/ProfilePopover', () => {
             openModal: jest.fn(),
             closeModal: jest.fn(),
             loadBot: jest.fn(),
+            setCustomStatusInitialisationState: jest.fn(),
         },
     };
 

--- a/components/profile_popover/profile_popover.test.jsx
+++ b/components/profile_popover/profile_popover.test.jsx
@@ -22,6 +22,7 @@ describe('components/ProfilePopover', () => {
         isInCurrentTeam: true,
         teamUrl: '',
         canManageAnyChannelMembersInCurrentTeam: true,
+        isCustomStatusEnabled: true,
         actions: {
             getMembershipForCurrentEntities: jest.fn(),
             openDirectChannelToUserId: jest.fn(),
@@ -87,5 +88,31 @@ describe('components/ProfilePopover', () => {
         };
         expect(wrapper.find(Pluggable).first().props()).toEqual({...pluggableProps, pluggableName: 'PopoverUserAttributes'});
         expect(wrapper.find(Pluggable).last().props()).toEqual({...pluggableProps, pluggableName: 'PopoverUserActions'});
+    });
+
+    test('should match snapshot when tooltip is enabled', () => {
+        const wrapper = shallowWithIntl(
+            <ProfilePopover {...baseProps}/>,
+        );
+
+        wrapper.setState({showCustomStatusTooltip: true});
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should enable tooltip when needed', () => {
+        const wrapper = shallowWithIntl(
+            <ProfilePopover {...baseProps}/>,
+        );
+
+        const instance = wrapper.instance();
+        instance.customStatusTextRef = {
+            current: {
+                offsetWidth: 50,
+                scrollWidth: 60,
+            },
+        };
+
+        instance.showCustomStatusTextTooltip();
+        expect(instance.state.showCustomStatusTooltip).toBe(true);
     });
 });

--- a/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
+++ b/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
@@ -4,6 +4,8 @@ exports[`components/StatusDropdown should match snapshot in default state 1`] = 
 <MenuWrapper
   animationComponent={[Function]}
   className="status-dropdown-menu"
+  onToggle={[Function]}
+  open={false}
 >
   <div
     className="status-wrapper status-selector"
@@ -99,10 +101,351 @@ exports[`components/StatusDropdown should match snapshot in default state 1`] = 
 </MenuWrapper>
 `;
 
+exports[`components/StatusDropdown should match snapshot when tooltip is enabled 1`] = `
+<MenuWrapper
+  animationComponent={[Function]}
+  className="status-dropdown-menu"
+  onToggle={[Function]}
+  open={true}
+>
+  <div
+    className="status-wrapper status-selector"
+  >
+    <button
+      aria-label="Set a status"
+      className="status style--none"
+    >
+      <StatusIcon
+        button={true}
+        className=""
+        status="offline"
+      />
+    </button>
+    <span
+      className="status status-edit edit"
+    >
+      <FormattedMessage
+        defaultMessage="Dropdown Icon"
+        id="generic_icons.dropdown"
+      >
+        <Component />
+      </FormattedMessage>
+    </span>
+  </div>
+  <Menu
+    ariaLabel="Set a status"
+    id="statusDropdownMenu"
+  >
+    <MenuGroup>
+      <MenuItemAction
+        ariaLabel="out of office"
+        extraText="Automatic Replies are enabled"
+        onClick={[Function]}
+        show={false}
+        text="Out of office"
+      />
+    </MenuGroup>
+    <div
+      className="custom_status__row cursor--pointer a11y--active"
+      onClick={[Function]}
+    >
+      <div
+        className="custom_status__icon"
+      >
+        <EmojiIcon
+          className="custom-status-emoji"
+        />
+      </div>
+      <span
+        className="custom_status__text"
+      >
+        Set a Custom Status
+      </span>
+    </div>
+    <MenuGroup>
+      <MenuItemAction
+        ariaLabel="online"
+        icon={
+          <StatusOnlineIcon
+            className="online--icon"
+          />
+        }
+        id="status-menu-online"
+        onClick={[Function]}
+        show={true}
+        text="Online"
+      />
+      <MenuItemAction
+        ariaLabel="away"
+        icon={
+          <StatusAwayIcon
+            className="away--icon"
+          />
+        }
+        id="status-menu-away"
+        onClick={[Function]}
+        show={true}
+        text="Away"
+      />
+      <MenuItemAction
+        ariaLabel="do not disturb. disables desktop, email and push notifications"
+        extraText="Disables all notifications"
+        icon={
+          <StatusDndIcon
+            className="dnd--icon"
+          />
+        }
+        id="status-menu-dnd"
+        onClick={[Function]}
+        show={true}
+        text="Do not disturb"
+      />
+      <MenuItemAction
+        ariaLabel="offline"
+        icon={<StatusOfflineIcon />}
+        id="status-menu-offline"
+        onClick={[Function]}
+        show={true}
+        text="Offline"
+      />
+    </MenuGroup>
+  </Menu>
+</MenuWrapper>
+`;
+
+exports[`components/StatusDropdown should match snapshot with custom status enabled 1`] = `
+<MenuWrapper
+  animationComponent={[Function]}
+  className="status-dropdown-menu"
+  onToggle={[Function]}
+  open={true}
+>
+  <div
+    className="status-wrapper status-selector"
+  >
+    <button
+      aria-label="Set a status"
+      className="status style--none"
+    >
+      <StatusIcon
+        button={true}
+        className=""
+        status="offline"
+      />
+    </button>
+    <span
+      className="status status-edit edit"
+    >
+      <FormattedMessage
+        defaultMessage="Dropdown Icon"
+        id="generic_icons.dropdown"
+      >
+        <Component />
+      </FormattedMessage>
+    </span>
+  </div>
+  <Menu
+    ariaLabel="Set a status"
+    id="statusDropdownMenu"
+  >
+    <MenuGroup>
+      <MenuItemAction
+        ariaLabel="out of office"
+        extraText="Automatic Replies are enabled"
+        onClick={[Function]}
+        show={false}
+        text="Out of office"
+      />
+    </MenuGroup>
+    <div
+      className="custom_status__row cursor--pointer a11y--active"
+      onClick={[Function]}
+    >
+      <div
+        className="custom_status__icon"
+      >
+        <EmojiIcon
+          className="custom-status-emoji"
+        />
+      </div>
+      <span
+        className="custom_status__text"
+      >
+        Set a Custom Status
+      </span>
+    </div>
+    <MenuGroup>
+      <MenuItemAction
+        ariaLabel="online"
+        icon={
+          <StatusOnlineIcon
+            className="online--icon"
+          />
+        }
+        id="status-menu-online"
+        onClick={[Function]}
+        show={true}
+        text="Online"
+      />
+      <MenuItemAction
+        ariaLabel="away"
+        icon={
+          <StatusAwayIcon
+            className="away--icon"
+          />
+        }
+        id="status-menu-away"
+        onClick={[Function]}
+        show={true}
+        text="Away"
+      />
+      <MenuItemAction
+        ariaLabel="do not disturb. disables desktop, email and push notifications"
+        extraText="Disables all notifications"
+        icon={
+          <StatusDndIcon
+            className="dnd--icon"
+          />
+        }
+        id="status-menu-dnd"
+        onClick={[Function]}
+        show={true}
+        text="Do not disturb"
+      />
+      <MenuItemAction
+        ariaLabel="offline"
+        icon={<StatusOfflineIcon />}
+        id="status-menu-offline"
+        onClick={[Function]}
+        show={true}
+        text="Offline"
+      />
+    </MenuGroup>
+  </Menu>
+</MenuWrapper>
+`;
+
+exports[`components/StatusDropdown should match snapshot with custom status pulsating dot enabled 1`] = `
+<MenuWrapper
+  animationComponent={[Function]}
+  className="status-dropdown-menu"
+  onToggle={[Function]}
+  open={true}
+>
+  <div
+    className="status-wrapper status-selector"
+  >
+    <button
+      aria-label="Set a status"
+      className="status style--none"
+    >
+      <StatusIcon
+        button={true}
+        className=""
+        status="offline"
+      />
+    </button>
+    <span
+      className="status status-edit edit"
+    >
+      <FormattedMessage
+        defaultMessage="Dropdown Icon"
+        id="generic_icons.dropdown"
+      >
+        <Component />
+      </FormattedMessage>
+    </span>
+  </div>
+  <Menu
+    ariaLabel="Set a status"
+    id="statusDropdownMenu"
+  >
+    <MenuGroup>
+      <MenuItemAction
+        ariaLabel="out of office"
+        extraText="Automatic Replies are enabled"
+        onClick={[Function]}
+        show={false}
+        text="Out of office"
+      />
+    </MenuGroup>
+    <div
+      className="custom_status__row cursor--pointer a11y--active"
+      onClick={[Function]}
+    >
+      <div
+        className="custom_status__icon"
+      >
+        <EmojiIcon
+          className="custom-status-emoji"
+        />
+      </div>
+      <span
+        className="custom_status__text"
+      >
+        Set a Custom Status
+      </span>
+      <div
+        className="pulsating_dot"
+      />
+    </div>
+    <MenuGroup>
+      <MenuItemAction
+        ariaLabel="online"
+        icon={
+          <StatusOnlineIcon
+            className="online--icon"
+          />
+        }
+        id="status-menu-online"
+        onClick={[Function]}
+        show={true}
+        text="Online"
+      />
+      <MenuItemAction
+        ariaLabel="away"
+        icon={
+          <StatusAwayIcon
+            className="away--icon"
+          />
+        }
+        id="status-menu-away"
+        onClick={[Function]}
+        show={true}
+        text="Away"
+      />
+      <MenuItemAction
+        ariaLabel="do not disturb. disables desktop, email and push notifications"
+        extraText="Disables all notifications"
+        icon={
+          <StatusDndIcon
+            className="dnd--icon"
+          />
+        }
+        id="status-menu-dnd"
+        onClick={[Function]}
+        show={true}
+        text="Do not disturb"
+      />
+      <MenuItemAction
+        ariaLabel="offline"
+        icon={<StatusOfflineIcon />}
+        id="status-menu-offline"
+        onClick={[Function]}
+        show={true}
+        text="Offline"
+      />
+    </MenuGroup>
+  </Menu>
+</MenuWrapper>
+`;
+
 exports[`components/StatusDropdown should match snapshot with profile picture URL 1`] = `
 <MenuWrapper
   animationComponent={[Function]}
   className="status-dropdown-menu"
+  onToggle={[Function]}
+  open={false}
 >
   <div
     className="status-wrapper status-selector"
@@ -111,6 +454,107 @@ exports[`components/StatusDropdown should match snapshot with profile picture UR
       size="lg"
       url="http://localhost:8065/api/v4/users/jsx5jmdiyjyuzp9rzwfaf5pwjo/image?_=1590519110944"
     />
+    <button
+      aria-label="Set a status"
+      className="status style--none"
+    >
+      <StatusIcon
+        button={true}
+        className=""
+        status="offline"
+      />
+    </button>
+    <span
+      className="status status-edit edit"
+    >
+      <FormattedMessage
+        defaultMessage="Dropdown Icon"
+        id="generic_icons.dropdown"
+      >
+        <Component />
+      </FormattedMessage>
+    </span>
+  </div>
+  <Menu
+    ariaLabel="Set a status"
+    id="statusDropdownMenu"
+  >
+    <MenuHeader>
+      <FormattedMessage
+        defaultMessage="Status"
+        id="status_dropdown.set_your_status"
+      />
+    </MenuHeader>
+    <MenuGroup>
+      <MenuItemAction
+        ariaLabel="out of office"
+        extraText="Automatic Replies are enabled"
+        onClick={[Function]}
+        show={false}
+        text="Out of office"
+      />
+    </MenuGroup>
+    <MenuGroup>
+      <MenuItemAction
+        ariaLabel="online"
+        icon={
+          <StatusOnlineIcon
+            className="online--icon"
+          />
+        }
+        id="status-menu-online"
+        onClick={[Function]}
+        show={true}
+        text="Online"
+      />
+      <MenuItemAction
+        ariaLabel="away"
+        icon={
+          <StatusAwayIcon
+            className="away--icon"
+          />
+        }
+        id="status-menu-away"
+        onClick={[Function]}
+        show={true}
+        text="Away"
+      />
+      <MenuItemAction
+        ariaLabel="do not disturb. disables desktop, email and push notifications"
+        extraText="Disables all notifications"
+        icon={
+          <StatusDndIcon
+            className="dnd--icon"
+          />
+        }
+        id="status-menu-dnd"
+        onClick={[Function]}
+        show={true}
+        text="Do not disturb"
+      />
+      <MenuItemAction
+        ariaLabel="offline"
+        icon={<StatusOfflineIcon />}
+        id="status-menu-offline"
+        onClick={[Function]}
+        show={true}
+        text="Offline"
+      />
+    </MenuGroup>
+  </Menu>
+</MenuWrapper>
+`;
+
+exports[`components/StatusDropdown should match snapshot with status dropdown open 1`] = `
+<MenuWrapper
+  animationComponent={[Function]}
+  className="status-dropdown-menu"
+  onToggle={[Function]}
+  open={true}
+>
+  <div
+    className="status-wrapper status-selector"
+  >
     <button
       aria-label="Set a status"
       className="status style--none"

--- a/components/status_dropdown/index.jsx
+++ b/components/status_dropdown/index.jsx
@@ -3,7 +3,7 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import {setStatus} from 'mattermost-redux/actions/users';
+import {setStatus, unsetCustomStatus} from 'mattermost-redux/actions/users';
 import {Client4} from 'mattermost-redux/client';
 import {getCurrentUser, getStatusForUserId} from 'mattermost-redux/selectors/entities/users';
 import {Preferences} from 'mattermost-redux/constants';
@@ -13,9 +13,8 @@ import {openModal} from 'actions/views/modals';
 import {setStatusDropdown} from 'actions/views/status_dropdown';
 
 import StatusDropdown from 'components/status_dropdown/status_dropdown.jsx';
-import {unsetUserCustomStatus, setCustomStatusInitialisationState} from 'actions/views/custom_status';
 import {getCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
-import {showCustomStatusPulsatingDot} from 'utils/custom_status';
+import {showStatusDropdownPulsatingDot} from 'utils/custom_status';
 import {isStatusDropdownOpen} from 'selectors/views/status_dropdown';
 
 function mapStateToProps(state) {
@@ -34,7 +33,7 @@ function mapStateToProps(state) {
         customStatus: getCustomStatus(state, userId),
         isCustomStatusEnabled: isCustomStatusEnabled(state),
         isStatusDropdownOpen: isStatusDropdownOpen(state),
-        showCustomStatusPulsatingDot: showCustomStatusPulsatingDot(state),
+        showCustomStatusPulsatingDot: showStatusDropdownPulsatingDot(state),
     };
 }
 
@@ -43,9 +42,8 @@ function mapDispatchToProps(dispatch) {
         actions: bindActionCreators({
             openModal,
             setStatus,
-            unsetUserCustomStatus,
+            unsetCustomStatus,
             setStatusDropdown,
-            setCustomStatusInitialisationState,
         }, dispatch),
     };
 }

--- a/components/status_dropdown/index.jsx
+++ b/components/status_dropdown/index.jsx
@@ -10,10 +10,12 @@ import {Preferences} from 'mattermost-redux/constants';
 import {get} from 'mattermost-redux/selectors/entities/preferences';
 
 import {openModal} from 'actions/views/modals';
+import {toggleStatusDropdown} from 'actions/views/status_dropdown';
 
 import StatusDropdown from 'components/status_dropdown/status_dropdown.jsx';
-import {unsetUserCustomStatus} from 'actions/views/custom_status';
-import {getCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
+import {unsetUserCustomStatus, setFirstTimeUserProperties} from 'actions/views/custom_status';
+import {getCustomStatus, isCustomStatusEnabled, hasClickedOnSetStatusBefore} from 'selectors/views/custom_status';
+import {isStatusDropdownOpen} from 'selectors/views/status_dropdown';
 
 function mapStateToProps(state) {
     const currentUser = getCurrentUser(state);
@@ -30,6 +32,8 @@ function mapStateToProps(state) {
         status: getStatusForUserId(state, userId),
         customStatus: getCustomStatus(state, userId),
         isCustomStatusEnabled: isCustomStatusEnabled(state),
+        isStatusDropdownOpen: isStatusDropdownOpen(state),
+        showPulsatingDot: !hasClickedOnSetStatusBefore(state, userId),
     };
 }
 
@@ -39,6 +43,8 @@ function mapDispatchToProps(dispatch) {
             openModal,
             setStatus,
             unsetUserCustomStatus,
+            toggleStatusDropdown,
+            setFirstTimeUserProperties,
         }, dispatch),
     };
 }

--- a/components/status_dropdown/index.jsx
+++ b/components/status_dropdown/index.jsx
@@ -13,7 +13,6 @@ import {openModal} from 'actions/views/modals';
 import {setStatusDropdown} from 'actions/views/status_dropdown';
 
 import StatusDropdown from 'components/status_dropdown/status_dropdown.jsx';
-import {setCustomStatusInitialisationState} from 'actions/views/custom_status';
 import {getCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
 import {showCustomStatusPulsatingDotAndPostHeader} from 'utils/custom_status';
 import {isStatusDropdownOpen} from 'selectors/views/status_dropdown';
@@ -45,7 +44,6 @@ function mapDispatchToProps(dispatch) {
             setStatus,
             unsetCustomStatus,
             setStatusDropdown,
-            setCustomStatusInitialisationState,
         }, dispatch),
     };
 }

--- a/components/status_dropdown/index.jsx
+++ b/components/status_dropdown/index.jsx
@@ -10,11 +10,12 @@ import {Preferences} from 'mattermost-redux/constants';
 import {get} from 'mattermost-redux/selectors/entities/preferences';
 
 import {openModal} from 'actions/views/modals';
-import {toggleStatusDropdown} from 'actions/views/status_dropdown';
+import {setStatusDropdown} from 'actions/views/status_dropdown';
 
 import StatusDropdown from 'components/status_dropdown/status_dropdown.jsx';
-import {unsetUserCustomStatus, setFirstTimeUserProperties} from 'actions/views/custom_status';
-import {getCustomStatus, isCustomStatusEnabled, hasClickedOnSetStatusBefore} from 'selectors/views/custom_status';
+import {unsetUserCustomStatus, setCustomStatusInitialProps} from 'actions/views/custom_status';
+import {getCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
+import {showPulsatingDot} from 'utils/custom_status';
 import {isStatusDropdownOpen} from 'selectors/views/status_dropdown';
 
 function mapStateToProps(state) {
@@ -33,7 +34,7 @@ function mapStateToProps(state) {
         customStatus: getCustomStatus(state, userId),
         isCustomStatusEnabled: isCustomStatusEnabled(state),
         isStatusDropdownOpen: isStatusDropdownOpen(state),
-        showPulsatingDot: !hasClickedOnSetStatusBefore(state, userId),
+        showPulsatingDot: showPulsatingDot(state),
     };
 }
 
@@ -43,8 +44,8 @@ function mapDispatchToProps(dispatch) {
             openModal,
             setStatus,
             unsetUserCustomStatus,
-            toggleStatusDropdown,
-            setFirstTimeUserProperties,
+            setStatusDropdown,
+            setCustomStatusInitialProps,
         }, dispatch),
     };
 }

--- a/components/status_dropdown/index.jsx
+++ b/components/status_dropdown/index.jsx
@@ -3,17 +3,19 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import {setStatus} from 'mattermost-redux/actions/users';
+import {setStatus, unsetCustomStatus} from 'mattermost-redux/actions/users';
 import {Client4} from 'mattermost-redux/client';
 import {getCurrentUser, getStatusForUserId} from 'mattermost-redux/selectors/entities/users';
 import {Preferences} from 'mattermost-redux/constants';
 import {get} from 'mattermost-redux/selectors/entities/preferences';
 
 import {openModal} from 'actions/views/modals';
+import {setStatusDropdown} from 'actions/views/status_dropdown';
 
 import StatusDropdown from 'components/status_dropdown/status_dropdown.jsx';
-import {unsetUserCustomStatus} from 'actions/views/custom_status';
 import {getCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
+import {showCustomStatusPulsatingDotAndPostHeader} from 'utils/custom_status';
+import {isStatusDropdownOpen} from 'selectors/views/status_dropdown';
 
 function mapStateToProps(state) {
     const currentUser = getCurrentUser(state);
@@ -30,6 +32,8 @@ function mapStateToProps(state) {
         status: getStatusForUserId(state, userId),
         customStatus: getCustomStatus(state, userId),
         isCustomStatusEnabled: isCustomStatusEnabled(state),
+        isStatusDropdownOpen: isStatusDropdownOpen(state),
+        showCustomStatusPulsatingDot: showCustomStatusPulsatingDotAndPostHeader(state),
     };
 }
 
@@ -38,7 +42,8 @@ function mapDispatchToProps(dispatch) {
         actions: bindActionCreators({
             openModal,
             setStatus,
-            unsetUserCustomStatus,
+            unsetCustomStatus,
+            setStatusDropdown,
         }, dispatch),
     };
 }

--- a/components/status_dropdown/index.jsx
+++ b/components/status_dropdown/index.jsx
@@ -13,7 +13,7 @@ import {openModal} from 'actions/views/modals';
 import {setStatusDropdown} from 'actions/views/status_dropdown';
 
 import StatusDropdown from 'components/status_dropdown/status_dropdown.jsx';
-import {unsetUserCustomStatus, setCustomStatusInitialProps} from 'actions/views/custom_status';
+import {unsetUserCustomStatus, setCustomStatusInitialisationState} from 'actions/views/custom_status';
 import {getCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
 import {showPulsatingDot} from 'utils/custom_status';
 import {isStatusDropdownOpen} from 'selectors/views/status_dropdown';
@@ -45,7 +45,7 @@ function mapDispatchToProps(dispatch) {
             setStatus,
             unsetUserCustomStatus,
             setStatusDropdown,
-            setCustomStatusInitialProps,
+            setCustomStatusInitialisationState,
         }, dispatch),
     };
 }

--- a/components/status_dropdown/index.jsx
+++ b/components/status_dropdown/index.jsx
@@ -3,7 +3,7 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import {setStatus} from 'mattermost-redux/actions/users';
+import {setStatus, unsetCustomStatus} from 'mattermost-redux/actions/users';
 import {Client4} from 'mattermost-redux/client';
 import {getCurrentUser, getStatusForUserId} from 'mattermost-redux/selectors/entities/users';
 import {Preferences} from 'mattermost-redux/constants';
@@ -13,7 +13,7 @@ import {openModal} from 'actions/views/modals';
 import {setStatusDropdown} from 'actions/views/status_dropdown';
 
 import StatusDropdown from 'components/status_dropdown/status_dropdown.jsx';
-import {unsetUserCustomStatus, setCustomStatusInitialisationState} from 'actions/views/custom_status';
+import {setCustomStatusInitialisationState} from 'actions/views/custom_status';
 import {getCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
 import {showCustomStatusPulsatingDotAndPostHeader} from 'utils/custom_status';
 import {isStatusDropdownOpen} from 'selectors/views/status_dropdown';
@@ -43,7 +43,7 @@ function mapDispatchToProps(dispatch) {
         actions: bindActionCreators({
             openModal,
             setStatus,
-            unsetUserCustomStatus,
+            unsetCustomStatus,
             setStatusDropdown,
             setCustomStatusInitialisationState,
         }, dispatch),

--- a/components/status_dropdown/index.jsx
+++ b/components/status_dropdown/index.jsx
@@ -15,7 +15,7 @@ import {setStatusDropdown} from 'actions/views/status_dropdown';
 import StatusDropdown from 'components/status_dropdown/status_dropdown.jsx';
 import {unsetUserCustomStatus, setCustomStatusInitialisationState} from 'actions/views/custom_status';
 import {getCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
-import {showCustomStatusLinkAndPulsatingDot} from 'utils/custom_status';
+import {showCustomStatusPulsatingDotAndPostHeader} from 'utils/custom_status';
 import {isStatusDropdownOpen} from 'selectors/views/status_dropdown';
 
 function mapStateToProps(state) {
@@ -34,7 +34,7 @@ function mapStateToProps(state) {
         customStatus: getCustomStatus(state, userId),
         isCustomStatusEnabled: isCustomStatusEnabled(state),
         isStatusDropdownOpen: isStatusDropdownOpen(state),
-        showCustomStatusPulsatingDot: showCustomStatusLinkAndPulsatingDot(state),
+        showCustomStatusPulsatingDot: showCustomStatusPulsatingDotAndPostHeader(state),
     };
 }
 

--- a/components/status_dropdown/index.jsx
+++ b/components/status_dropdown/index.jsx
@@ -15,7 +15,7 @@ import {setStatusDropdown} from 'actions/views/status_dropdown';
 import StatusDropdown from 'components/status_dropdown/status_dropdown.jsx';
 import {unsetUserCustomStatus, setCustomStatusInitialisationState} from 'actions/views/custom_status';
 import {getCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
-import {showPulsatingDot} from 'utils/custom_status';
+import {showCustomStatusPulsatingDot} from 'utils/custom_status';
 import {isStatusDropdownOpen} from 'selectors/views/status_dropdown';
 
 function mapStateToProps(state) {
@@ -34,7 +34,7 @@ function mapStateToProps(state) {
         customStatus: getCustomStatus(state, userId),
         isCustomStatusEnabled: isCustomStatusEnabled(state),
         isStatusDropdownOpen: isStatusDropdownOpen(state),
-        showPulsatingDot: showPulsatingDot(state),
+        showCustomStatusPulsatingDot: showCustomStatusPulsatingDot(state),
     };
 }
 

--- a/components/status_dropdown/index.jsx
+++ b/components/status_dropdown/index.jsx
@@ -15,7 +15,7 @@ import {setStatusDropdown} from 'actions/views/status_dropdown';
 import StatusDropdown from 'components/status_dropdown/status_dropdown.jsx';
 import {unsetUserCustomStatus, setCustomStatusInitialisationState} from 'actions/views/custom_status';
 import {getCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
-import {showCustomStatusPulsatingDot} from 'utils/custom_status';
+import {showCustomStatusLinkAndPulsatingDot} from 'utils/custom_status';
 import {isStatusDropdownOpen} from 'selectors/views/status_dropdown';
 
 function mapStateToProps(state) {
@@ -34,7 +34,7 @@ function mapStateToProps(state) {
         customStatus: getCustomStatus(state, userId),
         isCustomStatusEnabled: isCustomStatusEnabled(state),
         isStatusDropdownOpen: isStatusDropdownOpen(state),
-        showCustomStatusPulsatingDot: showCustomStatusPulsatingDot(state),
+        showCustomStatusPulsatingDot: showCustomStatusLinkAndPulsatingDot(state),
     };
 }
 

--- a/components/status_dropdown/status_dropdown.jsx
+++ b/components/status_dropdown/status_dropdown.jsx
@@ -235,6 +235,10 @@ export default class StatusDropdown extends React.PureComponent {
                     </div>
                 );
 
+            const pulsatingDot = !isStatusSet && (
+                <div className='pulsating_dot'/>
+            );
+
             customStatusComponent = (
                 <div
                     className='custom_status__row cursor--pointer a11y--active'

--- a/components/status_dropdown/status_dropdown.jsx
+++ b/components/status_dropdown/status_dropdown.jsx
@@ -36,10 +36,13 @@ export default class StatusDropdown extends React.PureComponent {
         actions: PropTypes.shape({
             openModal: PropTypes.func.isRequired,
             setStatus: PropTypes.func.isRequired,
-            unsetUserCustomStatus: PropTypes.func.isRequired,
+            unsetCustomStatus: PropTypes.func.isRequired,
+            setStatusDropdown: PropTypes.func.isRequired,
         }).isRequired,
         customStatus: PropTypes.object,
         isCustomStatusEnabled: PropTypes.bool.isRequired,
+        isStatusDropdownOpen: PropTypes.bool.isRequired,
+        showCustomStatusPulsatingDot: PropTypes.bool.isRequired,
     }
 
     static defaultProps = {
@@ -147,13 +150,14 @@ export default class StatusDropdown extends React.PureComponent {
     }
     handleClearStatus = (e) => {
         e.stopPropagation();
-        this.props.actions.unsetUserCustomStatus();
+        this.props.actions.unsetCustomStatus();
     };
 
     onToggle = (open) => {
         if (open) {
             this.showCustomStatusTextTooltip();
         }
+        this.props.actions.setStatusDropdown(open);
     }
 
     render() {
@@ -235,7 +239,7 @@ export default class StatusDropdown extends React.PureComponent {
                     </div>
                 );
 
-            const pulsatingDot = !isStatusSet && (
+            const pulsatingDot = !isStatusSet && this.props.showCustomStatusPulsatingDot && (
                 <div className='pulsating_dot'/>
             );
 
@@ -257,6 +261,7 @@ export default class StatusDropdown extends React.PureComponent {
             <MenuWrapper
                 onToggle={this.onToggle}
                 style={this.props.style}
+                open={this.props.isStatusDropdownOpen}
                 className={'status-dropdown-menu'}
             >
                 <div className='status-wrapper status-selector'>
@@ -278,14 +283,14 @@ export default class StatusDropdown extends React.PureComponent {
                     ariaLabel={localizeMessage('status_dropdown.menuAriaLabel', 'Set a status')}
                     id='statusDropdownMenu'
                 >
-                    {!this.props.isCustomStatusEnabled &&
+                    {!this.props.isCustomStatusEnabled && (
                         <Menu.Header>
                             <FormattedMessage
                                 id='status_dropdown.set_your_status'
                                 defaultMessage='Status'
                             />
                         </Menu.Header>
-                    }
+                    )}
                     <Menu.Group>
                         <Menu.ItemAction
                             show={this.isUserOutOfOffice()}

--- a/components/status_dropdown/status_dropdown.jsx
+++ b/components/status_dropdown/status_dropdown.jsx
@@ -36,7 +36,7 @@ export default class StatusDropdown extends React.PureComponent {
         actions: PropTypes.shape({
             openModal: PropTypes.func.isRequired,
             setStatus: PropTypes.func.isRequired,
-            unsetUserCustomStatus: PropTypes.func.isRequired,
+            unsetCustomStatus: PropTypes.func.isRequired,
             setStatusDropdown: PropTypes.func.isRequired,
             setCustomStatusInitialisationState: PropTypes.func.isRequired,
         }).isRequired,
@@ -154,7 +154,7 @@ export default class StatusDropdown extends React.PureComponent {
     }
     handleClearStatus = (e) => {
         e.stopPropagation();
-        this.props.actions.unsetUserCustomStatus();
+        this.props.actions.unsetCustomStatus();
     };
 
     onToggle = (open) => {

--- a/components/status_dropdown/status_dropdown.jsx
+++ b/components/status_dropdown/status_dropdown.jsx
@@ -38,7 +38,7 @@ export default class StatusDropdown extends React.PureComponent {
             setStatus: PropTypes.func.isRequired,
             unsetUserCustomStatus: PropTypes.func.isRequired,
             setStatusDropdown: PropTypes.func.isRequired,
-            setCustomStatusInitialProps: PropTypes.func.isRequired,
+            setCustomStatusInitialisationState: PropTypes.func.isRequired,
         }).isRequired,
         customStatus: PropTypes.object,
         isCustomStatusEnabled: PropTypes.bool.isRequired,
@@ -157,7 +157,7 @@ export default class StatusDropdown extends React.PureComponent {
     onToggle = (open) => {
         if (open) {
             this.showCustomStatusTextTooltip();
-            this.props.actions.setCustomStatusInitialProps({menuOpenedOnClick: Constants.CustomStatusInitialProps.MENU_OPENED_BY_SIDEBAR_HEADER});
+            this.props.actions.setCustomStatusInitialisationState({menuOpenedOnClick: Constants.CustomStatusInitialisationState.MENU_OPENED_BY_SIDEBAR_HEADER});
         }
         this.props.actions.setStatusDropdown(open);
     }

--- a/components/status_dropdown/status_dropdown.jsx
+++ b/components/status_dropdown/status_dropdown.jsx
@@ -36,9 +36,8 @@ export default class StatusDropdown extends React.PureComponent {
         actions: PropTypes.shape({
             openModal: PropTypes.func.isRequired,
             setStatus: PropTypes.func.isRequired,
-            unsetUserCustomStatus: PropTypes.func.isRequired,
+            unsetCustomStatus: PropTypes.func.isRequired,
             setStatusDropdown: PropTypes.func.isRequired,
-            setCustomStatusInitialisationState: PropTypes.func.isRequired,
         }).isRequired,
         customStatus: PropTypes.object,
         isCustomStatusEnabled: PropTypes.bool.isRequired,
@@ -151,13 +150,12 @@ export default class StatusDropdown extends React.PureComponent {
     }
     handleClearStatus = (e) => {
         e.stopPropagation();
-        this.props.actions.unsetUserCustomStatus();
+        this.props.actions.unsetCustomStatus();
     };
 
     onToggle = (open) => {
         if (open) {
             this.showCustomStatusTextTooltip();
-            this.props.actions.setCustomStatusInitialisationState({menuOpenedOnClick: Constants.CustomStatusInitialisationStates.MENU_OPENED_BY_SIDEBAR_HEADER});
         }
         this.props.actions.setStatusDropdown(open);
     }

--- a/components/status_dropdown/status_dropdown.jsx
+++ b/components/status_dropdown/status_dropdown.jsx
@@ -38,7 +38,6 @@ export default class StatusDropdown extends React.PureComponent {
             setStatus: PropTypes.func.isRequired,
             unsetCustomStatus: PropTypes.func.isRequired,
             setStatusDropdown: PropTypes.func.isRequired,
-            setCustomStatusInitialisationState: PropTypes.func.isRequired,
         }).isRequired,
         customStatus: PropTypes.object,
         isCustomStatusEnabled: PropTypes.bool.isRequired,
@@ -111,9 +110,6 @@ export default class StatusDropdown extends React.PureComponent {
         };
 
         this.props.actions.openModal(customStatusInputModalData);
-        if (this.props.showCustomStatusPulsatingDot) {
-            this.props.actions.setCustomStatusInitialisationState({hasClickedSetStatusBefore: true});
-        }
     }
 
     showCustomStatusTextTooltip = () => {

--- a/components/status_dropdown/status_dropdown.jsx
+++ b/components/status_dropdown/status_dropdown.jsx
@@ -157,6 +157,7 @@ export default class StatusDropdown extends React.PureComponent {
     onToggle = (open) => {
         if (open) {
             this.showCustomStatusTextTooltip();
+
             // this.props.actions.setCustomStatusInitialProps(Constants.CustomStatusInitialProps.CLICK_ON_SIDEBAR_HEADER_DROPDOWN_ICON)
         }
         this.props.actions.setStatusDropdown(open);

--- a/components/status_dropdown/status_dropdown.jsx
+++ b/components/status_dropdown/status_dropdown.jsx
@@ -111,6 +111,9 @@ export default class StatusDropdown extends React.PureComponent {
         };
 
         this.props.actions.openModal(customStatusInputModalData);
+        if (this.props.showCustomStatusPulsatingDot) {
+            this.props.actions.setCustomStatusInitialisationState({hasClickedSetStatusBefore: true});
+        }
     }
 
     showCustomStatusTextTooltip = () => {
@@ -157,7 +160,6 @@ export default class StatusDropdown extends React.PureComponent {
     onToggle = (open) => {
         if (open) {
             this.showCustomStatusTextTooltip();
-            this.props.actions.setCustomStatusInitialisationState({menuOpenedOnClick: Constants.CustomStatusInitialisationStates.MENU_OPENED_BY_SIDEBAR_HEADER});
         }
         this.props.actions.setStatusDropdown(open);
     }

--- a/components/status_dropdown/status_dropdown.jsx
+++ b/components/status_dropdown/status_dropdown.jsx
@@ -43,7 +43,7 @@ export default class StatusDropdown extends React.PureComponent {
         customStatus: PropTypes.object,
         isCustomStatusEnabled: PropTypes.bool.isRequired,
         isStatusDropdownOpen: PropTypes.bool.isRequired,
-        showPulsatingDot: PropTypes.bool.isRequired,
+        showCustomStatusPulsatingDot: PropTypes.bool.isRequired,
     }
 
     static defaultProps = {
@@ -157,7 +157,7 @@ export default class StatusDropdown extends React.PureComponent {
     onToggle = (open) => {
         if (open) {
             this.showCustomStatusTextTooltip();
-            this.props.actions.setCustomStatusInitialisationState({menuOpenedOnClick: Constants.CustomStatusInitialisationState.MENU_OPENED_BY_SIDEBAR_HEADER});
+            this.props.actions.setCustomStatusInitialisationState({menuOpenedOnClick: Constants.CustomStatusInitialisationStates.MENU_OPENED_BY_SIDEBAR_HEADER});
         }
         this.props.actions.setStatusDropdown(open);
     }
@@ -241,7 +241,7 @@ export default class StatusDropdown extends React.PureComponent {
                     </div>
                 );
 
-            const pulsatingDot = !isStatusSet && this.props.showPulsatingDot && (
+            const pulsatingDot = !isStatusSet && this.props.showCustomStatusPulsatingDot && (
                 <div className='pulsating_dot'/>
             );
 

--- a/components/status_dropdown/status_dropdown.jsx
+++ b/components/status_dropdown/status_dropdown.jsx
@@ -37,8 +37,8 @@ export default class StatusDropdown extends React.PureComponent {
             openModal: PropTypes.func.isRequired,
             setStatus: PropTypes.func.isRequired,
             unsetUserCustomStatus: PropTypes.func.isRequired,
-            toggleStatusDropdown: PropTypes.func.isRequired,
-            setFirstTimeUserProperties: PropTypes.func.isRequired,
+            setStatusDropdown: PropTypes.func.isRequired,
+            setCustomStatusInitialProps: PropTypes.func.isRequired,
         }).isRequired,
         customStatus: PropTypes.object,
         isCustomStatusEnabled: PropTypes.bool.isRequired,
@@ -110,7 +110,6 @@ export default class StatusDropdown extends React.PureComponent {
             dialogProps: {userId: this.props.userId},
         };
 
-        this.props.actions.setFirstTimeUserProperties(Constants.CustomStatusInitialProps.CLICK_ON_SET_STATUS);
         this.props.actions.openModal(customStatusInputModalData);
     }
 
@@ -158,8 +157,9 @@ export default class StatusDropdown extends React.PureComponent {
     onToggle = (open) => {
         if (open) {
             this.showCustomStatusTextTooltip();
+            // this.props.actions.setCustomStatusInitialProps(Constants.CustomStatusInitialProps.CLICK_ON_SIDEBAR_HEADER_DROPDOWN_ICON)
         }
-        this.props.actions.toggleStatusDropdown(open);
+        this.props.actions.setStatusDropdown(open);
     }
 
     render() {
@@ -241,7 +241,7 @@ export default class StatusDropdown extends React.PureComponent {
                     </div>
                 );
 
-            const pulsatingDot = !isStatusSet && (
+            const pulsatingDot = !isStatusSet && this.props.showPulsatingDot && (
                 <div className='pulsating_dot'/>
             );
 

--- a/components/status_dropdown/status_dropdown.jsx
+++ b/components/status_dropdown/status_dropdown.jsx
@@ -286,14 +286,14 @@ export default class StatusDropdown extends React.PureComponent {
                     ariaLabel={localizeMessage('status_dropdown.menuAriaLabel', 'Set a status')}
                     id='statusDropdownMenu'
                 >
-                    {!this.props.isCustomStatusEnabled &&
+                    {!this.props.isCustomStatusEnabled && (
                         <Menu.Header>
                             <FormattedMessage
                                 id='status_dropdown.set_your_status'
                                 defaultMessage='Status'
                             />
                         </Menu.Header>
-                    }
+                    )}
                     <Menu.Group>
                         <Menu.ItemAction
                             show={this.isUserOutOfOffice()}

--- a/components/status_dropdown/status_dropdown.jsx
+++ b/components/status_dropdown/status_dropdown.jsx
@@ -157,7 +157,7 @@ export default class StatusDropdown extends React.PureComponent {
     onToggle = (open) => {
         if (open) {
             this.showCustomStatusTextTooltip();
-            // this.props.actions.setCustomStatusInitialProps(Constants.CustomStatusInitialProps.CLICK_ON_SIDEBAR_HEADER_DROPDOWN_ICON)
+            this.props.actions.setCustomStatusInitialProps({menuOpenedOnClick: Constants.CustomStatusInitialProps.MENU_OPENED_BY_SIDEBAR_HEADER});
         }
         this.props.actions.setStatusDropdown(open);
     }

--- a/components/status_dropdown/status_dropdown.jsx
+++ b/components/status_dropdown/status_dropdown.jsx
@@ -37,9 +37,13 @@ export default class StatusDropdown extends React.PureComponent {
             openModal: PropTypes.func.isRequired,
             setStatus: PropTypes.func.isRequired,
             unsetUserCustomStatus: PropTypes.func.isRequired,
+            toggleStatusDropdown: PropTypes.func.isRequired,
+            setFirstTimeUserProperties: PropTypes.func.isRequired,
         }).isRequired,
         customStatus: PropTypes.object,
         isCustomStatusEnabled: PropTypes.bool.isRequired,
+        isStatusDropdownOpen: PropTypes.bool.isRequired,
+        showPulsatingDot: PropTypes.bool.isRequired,
     }
 
     static defaultProps = {
@@ -106,6 +110,7 @@ export default class StatusDropdown extends React.PureComponent {
             dialogProps: {userId: this.props.userId},
         };
 
+        this.props.actions.setFirstTimeUserProperties(Constants.CustomStatusInitialProps.CLICK_ON_SET_STATUS);
         this.props.actions.openModal(customStatusInputModalData);
     }
 
@@ -154,6 +159,7 @@ export default class StatusDropdown extends React.PureComponent {
         if (open) {
             this.showCustomStatusTextTooltip();
         }
+        this.props.actions.toggleStatusDropdown(open);
     }
 
     render() {
@@ -248,7 +254,7 @@ export default class StatusDropdown extends React.PureComponent {
                         {customStatusEmoji}
                     </div>
                     {customStatusTextComponent}
-                    {clearButton}
+                    {clearButton || pulsatingDot}
                 </div>
             );
         }
@@ -257,6 +263,7 @@ export default class StatusDropdown extends React.PureComponent {
             <MenuWrapper
                 onToggle={this.onToggle}
                 style={this.props.style}
+                open={this.props.isStatusDropdownOpen}
                 className={'status-dropdown-menu'}
             >
                 <div className='status-wrapper status-selector'>

--- a/components/status_dropdown/status_dropdown.scss
+++ b/components/status_dropdown/status_dropdown.scss
@@ -1,7 +1,7 @@
 .custom_status__row {
     display: flex;
     font-size: inherit;
-    padding: 0px 24px;
+    padding: 0 24px;
     align-items: center;
     height: 34px;
     max-width: 238px;
@@ -29,9 +29,71 @@
     background-size: 20px;
 }
 
-.custom_status__clear{
+.custom_status__clear {
     display: flex;
     align-items: center;
     margin-left: auto;
     color: rgba(var(--center-channel-color-rgb), 0.52);
+}
+
+.pulsating_dot {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: auto;
+    position: relative;
+    height: 12px;
+    width : 12px;
+    background-color : rgba(var(--online-indicator-rgb), 1);
+    border-radius : 50%;
+}
+
+.pulsating_dot:before, .pulsating_dot:after {
+    content:"";
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 12px;
+    width : 12px;
+    border-radius: 50%;
+    background-color : rgba(var(--online-indicator-rgb), 1);
+    display:block;
+}
+
+.pulsating_dot:after {
+    animation: pulse1 2s ease 0s infinite;
+}
+
+.pulsating_dot:before {
+    animation: pulse2 2s ease 0s infinite;
+}
+
+@keyframes pulse1 {
+    0% {
+        opacity: 1;
+        transform: scale(1);
+    }
+    80% {
+        opacity: 0;
+        transform: scale(2.5);
+    }
+    100% {
+        opacity: 0;
+        transform: scale(2.5);
+    }
+}
+
+@keyframes pulse2 {
+    0% {
+        opacity: 1;
+        transform: scale(1);
+    }
+    30% {
+        opacity: 1;
+        transform: scale(1);
+    }
+    100% {
+        opacity: 0;
+        transform: scale(2.5);
+    }
 }

--- a/components/status_dropdown/status_dropdown.scss
+++ b/components/status_dropdown/status_dropdown.scss
@@ -11,7 +11,7 @@
 
     &:active {
         background-color: rgba(var(--button-bg-rgb), 0.08);
-        color: v(button-bg);
+        color: var(--button-bg);
     }
 }
 .custom_status__icon{

--- a/components/status_dropdown/status_dropdown.scss
+++ b/components/status_dropdown/status_dropdown.scss
@@ -36,28 +36,27 @@
     color: rgba(var(--center-channel-color-rgb), 0.52);
 }
 
+.pulsating_dot, .pulsating_dot:before, .pulsating_dot:after {
+    height: 12px;
+    width : 12px;
+    background-color : var(--online-indicator-rgb);
+    border-radius : 50%;
+}
+
 .pulsating_dot {
     display: flex;
     align-items: center;
     justify-content: center;
     margin-left: auto;
     position: relative;
-    height: 12px;
-    width : 12px;
-    background-color : rgba(var(--online-indicator-rgb), 1);
-    border-radius : 50%;
 }
 
 .pulsating_dot:before, .pulsating_dot:after {
     content:"";
+    display:block;
     position: absolute;
     left: 0;
     top: 0;
-    height: 12px;
-    width : 12px;
-    border-radius: 50%;
-    background-color : rgba(var(--online-indicator-rgb), 1);
-    display:block;
 }
 
 .pulsating_dot:after {

--- a/components/status_dropdown/status_dropdown.scss
+++ b/components/status_dropdown/status_dropdown.scss
@@ -11,7 +11,7 @@
 
     &:active {
         background-color: rgba(var(--button-bg-rgb), 0.08);
-        color: v(button-bg);
+        color: var(--button-bg);
     }
 }
 .custom_status__icon{
@@ -36,28 +36,27 @@
     color: rgba(var(--center-channel-color-rgb), 0.52);
 }
 
+.pulsating_dot, .pulsating_dot:before, .pulsating_dot:after {
+    height: 12px;
+    width : 12px;
+    background-color : var(--online-indicator);
+    border-radius : 50%;
+}
+
 .pulsating_dot {
     display: flex;
     align-items: center;
     justify-content: center;
     margin-left: auto;
     position: relative;
-    height: 12px;
-    width : 12px;
-    background-color : rgba(var(--online-indicator-rgb), 1);
-    border-radius : 50%;
 }
 
 .pulsating_dot:before, .pulsating_dot:after {
     content:"";
+    display:block;
     position: absolute;
     left: 0;
     top: 0;
-    height: 12px;
-    width : 12px;
-    border-radius: 50%;
-    background-color : rgba(var(--online-indicator-rgb), 1);
-    display:block;
 }
 
 .pulsating_dot:after {

--- a/components/status_dropdown/status_dropdown.scss
+++ b/components/status_dropdown/status_dropdown.scss
@@ -39,7 +39,7 @@
 .pulsating_dot, .pulsating_dot:before, .pulsating_dot:after {
     height: 12px;
     width : 12px;
-    background-color : var(--online-indicator-rgb);
+    background-color : var(--online-indicator);
     border-radius : 50%;
 }
 

--- a/components/status_dropdown/status_dropdown.test.tsx
+++ b/components/status_dropdown/status_dropdown.test.tsx
@@ -10,10 +10,16 @@ describe('components/StatusDropdown', () => {
     const actions = {
         openModal: jest.fn(),
         setStatus: jest.fn(),
+        unsetCustomStatus: jest.fn(),
+        setStatusDropdown: jest.fn(),
     };
 
     const baseProps = {
         actions,
+        userId: '',
+        isCustomStatusEnabled: false,
+        isStatusDropdownOpen: false,
+        showCustomStatusPulsatingDot: false,
     };
 
     test('should match snapshot in default state', () => {
@@ -33,5 +39,80 @@ describe('components/StatusDropdown', () => {
             <StatusDropdown {...props}/>,
         );
         expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot with status dropdown open', () => {
+        const props = {
+            ...baseProps,
+            isStatusDropdownOpen: true,
+        };
+
+        const wrapper = shallow(
+            <StatusDropdown {...props}/>,
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot with custom status enabled', () => {
+        const props = {
+            ...baseProps,
+            isStatusDropdownOpen: true,
+            isCustomStatusEnabled: true,
+        };
+
+        const wrapper = shallow(
+            <StatusDropdown {...props}/>,
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot with custom status pulsating dot enabled', () => {
+        const props = {
+            ...baseProps,
+            isStatusDropdownOpen: true,
+            isCustomStatusEnabled: true,
+            showCustomStatusPulsatingDot: true,
+        };
+
+        const wrapper = shallow(
+            <StatusDropdown {...props}/>,
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot when tooltip is enabled', () => {
+        const props = {
+            ...baseProps,
+            isStatusDropdownOpen: true,
+            isCustomStatusEnabled: true,
+        };
+        const wrapper = shallow(
+            <StatusDropdown {...props}/>,
+        );
+
+        wrapper.setState({showCustomStatusTooltip: true});
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should enable tooltip when needed', () => {
+        const props = {
+            ...baseProps,
+            isStatusDropdownOpen: true,
+            isCustomStatusEnabled: true,
+        };
+        const wrapper = shallow<StatusDropdown>(
+            <StatusDropdown {...props}/>,
+        );
+
+        const instance = wrapper.instance();
+        instance.customStatusTextRef = {
+            current: {
+                offsetWidth: 50,
+                scrollWidth: 60,
+            },
+        } as any;
+
+        instance.showCustomStatusTextTooltip();
+        expect(instance.state.showCustomStatusTooltip).toBe(true);
     });
 });

--- a/components/status_dropdown/status_dropdown.test.tsx
+++ b/components/status_dropdown/status_dropdown.test.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import {shallow} from 'enzyme';
 
 import StatusDropdown from './status_dropdown';
 
@@ -17,7 +17,7 @@ describe('components/StatusDropdown', () => {
 
     const baseProps = {
         actions,
-        userId: "",
+        userId: '',
         isCustomStatusEnabled: false,
         isStatusDropdownOpen: false,
         showCustomStatusPulsatingDot: false,
@@ -25,7 +25,7 @@ describe('components/StatusDropdown', () => {
 
     test('should match snapshot in default state', () => {
         const wrapper = shallow(
-            <StatusDropdown {...baseProps} />,
+            <StatusDropdown {...baseProps}/>,
         );
         expect(wrapper).toMatchSnapshot();
     });
@@ -37,8 +37,99 @@ describe('components/StatusDropdown', () => {
         };
 
         const wrapper = shallow(
-            <StatusDropdown {...props} />,
+            <StatusDropdown {...props}/>,
         );
         expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot with status dropdown open', () => {
+        const props = {
+            ...baseProps,
+            isStatusDropdownOpen: true,
+        };
+
+        const wrapper = shallow(
+            <StatusDropdown {...props}/>,
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot with custom status enabled', () => {
+        const props = {
+            ...baseProps,
+            isStatusDropdownOpen: true,
+            isCustomStatusEnabled: true,
+        };
+
+        const wrapper = shallow(
+            <StatusDropdown {...props}/>,
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot with custom status pulsating dot enabled', () => {
+        const props = {
+            ...baseProps,
+            isStatusDropdownOpen: true,
+            isCustomStatusEnabled: true,
+            showCustomStatusPulsatingDot: true,
+        };
+
+        const wrapper = shallow(
+            <StatusDropdown {...props}/>,
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot when tooltip is enabled', () => {
+        const props = {
+            ...baseProps,
+            isStatusDropdownOpen: true,
+            isCustomStatusEnabled: true,
+        };
+        const wrapper = shallow(
+            <StatusDropdown {...props}/>,
+        );
+
+        wrapper.setState({showCustomStatusTooltip: true});
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should enable tooltip when needed', () => {
+        const props = {
+            ...baseProps,
+            isStatusDropdownOpen: true,
+            isCustomStatusEnabled: true,
+        };
+        const wrapper = shallow<StatusDropdown>(
+            <StatusDropdown {...props}/>,
+        );
+
+        const instance = wrapper.instance();
+        instance.customStatusTextRef = {
+            current: {
+                offsetWidth: 50,
+                scrollWidth: 60,
+            },
+        } as any;
+
+        instance.showCustomStatusTextTooltip();
+        expect(instance.state.showCustomStatusTooltip).toBe(true);
+    });
+
+    test('setCustomStatusInitialisationState should be dispatched if showPulsatingDot is true and modal is opened', () => {
+        const props = {
+            ...baseProps,
+            isStatusDropdownOpen: true,
+            isCustomStatusEnabled: true,
+            showCustomStatusPulsatingDot: true,
+        };
+        const wrapper = shallow<StatusDropdown>(
+            <StatusDropdown {...props}/>,
+        );
+
+        const instance = wrapper.instance();
+        instance.showCustomStatusModal();
+        expect(props.actions.setCustomStatusInitialisationState).toBeCalledTimes(1);
     });
 });

--- a/components/status_dropdown/status_dropdown.test.tsx
+++ b/components/status_dropdown/status_dropdown.test.tsx
@@ -10,9 +10,8 @@ describe('components/StatusDropdown', () => {
     const actions = {
         openModal: jest.fn(),
         setStatus: jest.fn(),
-        unsetUserCustomStatus: jest.fn(),
+        unsetCustomStatus: jest.fn(),
         setStatusDropdown: jest.fn(),
-        setCustomStatusInitialisationState: jest.fn(),
     };
 
     const baseProps = {
@@ -115,21 +114,5 @@ describe('components/StatusDropdown', () => {
 
         instance.showCustomStatusTextTooltip();
         expect(instance.state.showCustomStatusTooltip).toBe(true);
-    });
-
-    test('setCustomStatusInitialisationState should be dispatched if showPulsatingDot is true and modal is opened', () => {
-        const props = {
-            ...baseProps,
-            isStatusDropdownOpen: true,
-            isCustomStatusEnabled: true,
-            showCustomStatusPulsatingDot: true,
-        };
-        const wrapper = shallow<StatusDropdown>(
-            <StatusDropdown {...props}/>,
-        );
-
-        const instance = wrapper.instance();
-        instance.showCustomStatusModal();
-        expect(props.actions.setCustomStatusInitialisationState).toBeCalledTimes(1);
     });
 });

--- a/components/status_dropdown/status_dropdown.test.tsx
+++ b/components/status_dropdown/status_dropdown.test.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {shallow} from 'enzyme';
+import { shallow } from 'enzyme';
 
 import StatusDropdown from './status_dropdown';
 
@@ -10,15 +10,22 @@ describe('components/StatusDropdown', () => {
     const actions = {
         openModal: jest.fn(),
         setStatus: jest.fn(),
+        unsetUserCustomStatus: jest.fn(),
+        setStatusDropdown: jest.fn(),
+        setCustomStatusInitialisationState: jest.fn(),
     };
 
     const baseProps = {
         actions,
+        userId: "",
+        isCustomStatusEnabled: false,
+        isStatusDropdownOpen: false,
+        showCustomStatusPulsatingDot: false,
     };
 
     test('should match snapshot in default state', () => {
         const wrapper = shallow(
-            <StatusDropdown {...baseProps}/>,
+            <StatusDropdown {...baseProps} />,
         );
         expect(wrapper).toMatchSnapshot();
     });
@@ -30,7 +37,7 @@ describe('components/StatusDropdown', () => {
         };
 
         const wrapper = shallow(
-            <StatusDropdown {...props}/>,
+            <StatusDropdown {...props} />,
         );
         expect(wrapper).toMatchSnapshot();
     });

--- a/components/widgets/menu/menu_wrapper.test.tsx
+++ b/components/widgets/menu/menu_wrapper.test.tsx
@@ -124,4 +124,14 @@ describe('components/MenuWrapper', () => {
         expect(event.stopPropagation).not.toHaveBeenCalled();
         expect(onToggle).toHaveBeenCalledWith(wrapper.instance().state.open);
     });
+    test('should initialize state from props if prop is given', () => {
+        const wrapper = shallow<MenuWrapper>(
+            <MenuWrapper open={true}>
+                <p>{'title'}</p>
+                <p>{'menu'}</p>
+            </MenuWrapper>,
+        );
+
+        expect(wrapper.state('open')).toBe(true);
+    });
 });

--- a/components/widgets/menu/menu_wrapper.tsx
+++ b/components/widgets/menu/menu_wrapper.tsx
@@ -22,6 +22,7 @@ type Props = {
     id?: string;
     isDisabled?: boolean;
     stopPropagationOnToggle?: boolean;
+    open?: boolean;
 }
 
 type State = {
@@ -50,6 +51,15 @@ export default class MenuWrapper extends React.PureComponent<Props, State> {
     public componentDidMount() {
         document.addEventListener('click', this.closeOnBlur, true);
         document.addEventListener('keyup', this.keyboardClose, true);
+    }
+
+    static getDerivedStateFromProps(props: Props, state: State) {
+        if (props.open !== undefined && props.open !== state.open) {
+            return {
+                open: props.open,
+            };
+        }
+        return null;
     }
 
     public componentWillUnmount() {

--- a/components/widgets/menu/menu_wrapper.tsx
+++ b/components/widgets/menu/menu_wrapper.tsx
@@ -54,10 +54,12 @@ export default class MenuWrapper extends React.PureComponent<Props, State> {
     }
 
     static getDerivedStateFromProps(props: Props, state: State) {
-        if (props.open && props.open !== state.open) {
-            return {open: true};
+        if (typeof props.open === 'boolean' && props.open !== state.open) {
+            return {
+                open: props.open,
+            };
         }
-        return {open: false};
+        return null;
     }
 
     public componentWillUnmount() {

--- a/components/widgets/menu/menu_wrapper.tsx
+++ b/components/widgets/menu/menu_wrapper.tsx
@@ -22,6 +22,7 @@ type Props = {
     id?: string;
     isDisabled?: boolean;
     stopPropagationOnToggle?: boolean;
+    open?: boolean;
 }
 
 type State = {
@@ -50,6 +51,15 @@ export default class MenuWrapper extends React.PureComponent<Props, State> {
     public componentDidMount() {
         document.addEventListener('click', this.closeOnBlur, true);
         document.addEventListener('keyup', this.keyboardClose, true);
+        if (this.props.open) {
+            this.setState({open: this.props.open});
+        }
+    }
+
+    public componentDidUpdate(prevProps: Props) {
+        if (typeof this.props.open === 'boolean' && prevProps.open !== this.props.open) {
+            this.setState({open: this.props.open});
+        }
     }
 
     public componentWillUnmount() {

--- a/components/widgets/menu/menu_wrapper.tsx
+++ b/components/widgets/menu/menu_wrapper.tsx
@@ -51,15 +51,13 @@ export default class MenuWrapper extends React.PureComponent<Props, State> {
     public componentDidMount() {
         document.addEventListener('click', this.closeOnBlur, true);
         document.addEventListener('keyup', this.keyboardClose, true);
-        if (this.props.open) {
-            this.setState({open: this.props.open});
-        }
     }
 
-    public componentDidUpdate(prevProps: Props) {
-        if (typeof this.props.open === 'boolean' && prevProps.open !== this.props.open) {
-            this.setState({open: this.props.open});
+    static getDerivedStateFromProps(props: Props, state: State) {
+        if (props.open && props.open !== state.open) {
+            return {open: true};
         }
+        return {open: false};
     }
 
     public componentWillUnmount() {

--- a/components/widgets/menu/menu_wrapper.tsx
+++ b/components/widgets/menu/menu_wrapper.tsx
@@ -51,15 +51,15 @@ export default class MenuWrapper extends React.PureComponent<Props, State> {
     public componentDidMount() {
         document.addEventListener('click', this.closeOnBlur, true);
         document.addEventListener('keyup', this.keyboardClose, true);
-        if (this.props.open) {
-            this.setState({open: this.props.open});
-        }
     }
 
-    public componentDidUpdate(prevProps: Props) {
-        if (typeof this.props.open === 'boolean' && prevProps.open !== this.props.open) {
-            this.setState({open: this.props.open});
+    static getDerivedStateFromProps(props: Props, state: State) {
+        if (props.open !== undefined && props.open !== state.open) {
+            return {
+                open: props.open,
+            };
         }
+        return null;
     }
 
     public componentWillUnmount() {

--- a/components/widgets/menu/menu_wrapper.tsx
+++ b/components/widgets/menu/menu_wrapper.tsx
@@ -54,7 +54,7 @@ export default class MenuWrapper extends React.PureComponent<Props, State> {
     }
 
     static getDerivedStateFromProps(props: Props, state: State) {
-        if (typeof props.open === 'boolean' && props.open !== state.open) {
+        if (props.open !== undefined && props.open !== state.open) {
             return {
                 open: props.open,
             };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12589,15 +12589,7 @@
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
       "dev": true,
       "requires": {
-        "icu4c-data": "0.67.2"
-      },
-      "dependencies": {
-        "icu4c-data": {
-          "version": "0.67.2",
-          "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.67.2.tgz",
-          "integrity": "sha512-OIRiop+k1IVf4TBLEOj910duoO9NKwtJLwp++qWT6KT5gRziHNt+5gwhcGuTqRy++RTK2gLoAIbk8KYCNxW++g==",
-          "dev": true
-        }
+        "icu4c-data": "0.64.2"
       }
     },
     "function-bind": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12589,15 +12589,7 @@
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
       "dev": true,
       "requires": {
-        "icu4c-data": "0.67.2"
-      },
-      "dependencies": {
-        "icu4c-data": {
-          "version": "0.67.2",
-          "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.67.2.tgz",
-          "integrity": "sha512-OIRiop+k1IVf4TBLEOj910duoO9NKwtJLwp++qWT6KT5gRziHNt+5gwhcGuTqRy++RTK2gLoAIbk8KYCNxW++g==",
-          "dev": true
-        }
+        "icu4c-data": "0.64.2"
       }
     },
     "function-bind": {
@@ -13496,6 +13488,12 @@
       "requires": {
         "postcss": "^7.0.14"
       }
+    },
+    "icu4c-data": {
+      "version": "0.64.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
+      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ==",
+      "dev": true
     },
     "identity-obj-proxy": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12589,7 +12589,7 @@
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
       "dev": true,
       "requires": {
-        "icu4c-data": "0.67.2"
+        "icu4c-data": "0.64.2"
       }
     },
     "function-bind": {
@@ -13488,6 +13488,12 @@
       "requires": {
         "postcss": "^7.0.14"
       }
+    },
+    "icu4c-data": {
+      "version": "0.64.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
+      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ==",
+      "dev": true
     },
     "identity-obj-proxy": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12589,7 +12589,7 @@
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
       "dev": true,
       "requires": {
-        "icu4c-data": "0.64.2"
+        "icu4c-data": "0.67.2"
       },
       "dependencies": {
         "icu4c-data": {

--- a/reducers/views/index.js
+++ b/reducers/views/index.js
@@ -22,6 +22,7 @@ import marketplace from './marketplace';
 import channelSidebar from './channel_sidebar';
 import textbox from './textbox';
 import nextSteps from './next_steps';
+import statusDropdown from './status_dropdown';
 
 export default combineReducers({
     admin,
@@ -43,4 +44,5 @@ export default combineReducers({
     textbox,
     channelSidebar,
     nextSteps,
+    statusDropdown,
 });

--- a/reducers/views/status_dropdown.ts
+++ b/reducers/views/status_dropdown.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {GenericAction} from 'mattermost-redux/types/actions';
+import {combineReducers} from 'redux';
+
+import {ActionTypes} from 'utils/constants';
+
+export function isOpen(state = false, action: GenericAction) {
+    switch (action.type) {
+    case ActionTypes.STATUS_DROPDOWN_TOGGLE:
+        return action.open;
+    default:
+        return state;
+    }
+}
+
+export default combineReducers({
+    isOpen,
+});

--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -1052,27 +1052,6 @@
         padding: 0;
     }
 
-    .post__header-set-custom-status {
-        background: #ecf3fd;
-        padding: 0px 4px;
-        border-radius: 4px;
-        margin-left: 8px;
-    }
-
-    .post__header-set-custom-status-icon > svg {
-        height: 14px;
-        width: 14px;
-        vertical-align: middle;
-        background: inherit;
-        fill: #3f76e6;
-        margin-right: 4px;
-    }
-    .post__header-set-custom-status-text {
-        font-weight: normal;
-        font-size: 12px;
-        color: #3f76e6;
-    }
-
     &.post--root {
         .comment-icon__container {
             visibility: visible;

--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -1165,10 +1165,6 @@
     }
 
     &.other--root {
-        .post__header-set-custom-status {
-            display: none;
-        }
-
         .comment-icon__container {
             &.icon--show {
                 visibility: visible;
@@ -1189,30 +1185,6 @@
                     top: -4px;
                 }
             }
-        }
-    }
-
-    &.other--root:last-of-type{
-        .post__header-set-custom-status {
-            display: revert;
-            background: #ecf3fd;
-            padding: 0px 4px;
-            border-radius: 4px;
-            margin-left: 8px;
-        }
-    
-        .post__header-set-custom-status-icon > svg {
-            height: 14px;
-            width: 14px;
-            vertical-align: middle;
-            background: inherit;
-            fill: #3f76e6;
-            margin-right: 4px;
-        }
-        .post__header-set-custom-status-text {
-            font-weight: normal;
-            font-size: 12px;
-            color: #3f76e6;
         }
     }
 

--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -1052,27 +1052,6 @@
         padding: 0;
     }
 
-    .post__header-set-custom-status {
-        background: #ecf3fd;
-        padding: 0px 4px;
-        border-radius: 4px;
-        margin-left: 8px;
-    }
-
-    .post__header-set-custom-status-icon > svg {
-        height: 14px;
-        width: 14px;
-        vertical-align: middle;
-        background: inherit;
-        fill: #3f76e6;
-        margin-right: 4px;
-    }
-    .post__header-set-custom-status-text {
-        font-weight: normal;
-        font-size: 12px;
-        color: #3f76e6;
-    }
-
     &.post--root {
         .comment-icon__container {
             visibility: visible;
@@ -1186,6 +1165,10 @@
     }
 
     &.other--root {
+        .post__header-set-custom-status {
+            display: none;
+        }
+
         .comment-icon__container {
             &.icon--show {
                 visibility: visible;
@@ -1206,6 +1189,30 @@
                     top: -4px;
                 }
             }
+        }
+    }
+
+    &.other--root:last-of-type{
+        .post__header-set-custom-status {
+            display: revert;
+            background: #ecf3fd;
+            padding: 0px 4px;
+            border-radius: 4px;
+            margin-left: 8px;
+        }
+    
+        .post__header-set-custom-status-icon > svg {
+            height: 14px;
+            width: 14px;
+            vertical-align: middle;
+            background: inherit;
+            fill: #3f76e6;
+            margin-right: 4px;
+        }
+        .post__header-set-custom-status-text {
+            font-weight: normal;
+            font-size: 12px;
+            color: #3f76e6;
         }
     }
 

--- a/selectors/views/custom_status.test.ts
+++ b/selectors/views/custom_status.test.ts
@@ -3,9 +3,10 @@
 import {getCurrentUser, getUser} from 'mattermost-redux/selectors/entities/users';
 
 import configureStore from 'store';
-import {getCustomStatus, getRecentCustomStatuses} from 'selectors/views/custom_status';
+import {getCustomStatus, getRecentCustomStatuses, isCustomStatusEnabled} from 'selectors/views/custom_status';
 
 import {TestHelper} from 'utils/test_helper';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 jest.mock('mattermost-redux/selectors/entities/users', () => {
     const original = jest.requireActual('mattermost-redux/selectors/entities/users');
@@ -13,6 +14,14 @@ jest.mock('mattermost-redux/selectors/entities/users', () => {
         ...original,
         getCurrentUser: jest.fn(),
         getUser: jest.fn(),
+    };
+});
+
+jest.mock('mattermost-redux/selectors/entities/general', () => {
+    const original = jest.requireActual('mattermost-redux/selectors/entities/general');
+    return {
+        ...original,
+        getConfig: jest.fn(),
     };
 });
 
@@ -52,7 +61,7 @@ describe('getRecentCustomStatuses', () => {
         getUser.mockReturnValue(user);
         expect(getRecentCustomStatuses(store.getState(), user.id)).toStrictEqual([]);
     });
-
+    
     it('should return arr of custom statuses if there are recent custom statuses', async () => {
         const store = await configureStore();
         user.props.recentCustomStatuses = JSON.stringify([customStatus]);
@@ -60,3 +69,20 @@ describe('getRecentCustomStatuses', () => {
         expect(getRecentCustomStatuses(store.getState(), user.id)).toStrictEqual([customStatus]);
     });
 });
+
+describe('isCustomStatusEnabled', () =>{
+    const config = {
+        EnableCustomUserStatuses : "true",
+    }
+    
+    it('should return true if EnableCustomUserStatuses is true in the config', async ()=>{
+        const store = await configureStore();
+        expect(isCustomStatusEnabled(store.getState())).toBeFalsy();
+    })
+
+    it('should return true if EnableCustomUserStatuses is true in the config', async ()=>{
+        const store = await configureStore();
+        getConfig.mockReturnValue(config);
+        expect(isCustomStatusEnabled(store.getState())).toBeTruthy();
+    })
+})

--- a/selectors/views/custom_status.test.ts
+++ b/selectors/views/custom_status.test.ts
@@ -2,11 +2,12 @@
 // See LICENSE.txt for license information.
 import {getCurrentUser, getUser} from 'mattermost-redux/selectors/entities/users';
 
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+
 import configureStore from 'store';
 import {getCustomStatus, getRecentCustomStatuses, isCustomStatusEnabled} from 'selectors/views/custom_status';
 
 import {TestHelper} from 'utils/test_helper';
-import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 jest.mock('mattermost-redux/selectors/entities/users', () => {
     const original = jest.requireActual('mattermost-redux/selectors/entities/users');
@@ -61,7 +62,7 @@ describe('getRecentCustomStatuses', () => {
         getUser.mockReturnValue(user);
         expect(getRecentCustomStatuses(store.getState(), user.id)).toStrictEqual([]);
     });
-    
+
     it('should return arr of custom statuses if there are recent custom statuses', async () => {
         const store = await configureStore();
         user.props.recentCustomStatuses = JSON.stringify([customStatus]);
@@ -70,19 +71,19 @@ describe('getRecentCustomStatuses', () => {
     });
 });
 
-describe('isCustomStatusEnabled', () =>{
+describe('isCustomStatusEnabled', () => {
     const config = {
-        EnableCustomUserStatuses : "true",
-    }
-    
-    it('should return true if EnableCustomUserStatuses is true in the config', async ()=>{
+        EnableCustomUserStatuses: 'true',
+    };
+
+    it('should return true if EnableCustomUserStatuses is true in the config', async () => {
         const store = await configureStore();
         expect(isCustomStatusEnabled(store.getState())).toBeFalsy();
-    })
+    });
 
-    it('should return true if EnableCustomUserStatuses is true in the config', async ()=>{
+    it('should return true if EnableCustomUserStatuses is true in the config', async () => {
         const store = await configureStore();
         getConfig.mockReturnValue(config);
         expect(isCustomStatusEnabled(store.getState())).toBeTruthy();
-    })
-})
+    });
+});

--- a/selectors/views/custom_status.test.ts
+++ b/selectors/views/custom_status.test.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {getCurrentUser, getUser} from 'mattermost-redux/selectors/entities/users';
+
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+
+import configureStore from 'store';
+import {getCustomStatus, getRecentCustomStatuses, isCustomStatusEnabled} from 'selectors/views/custom_status';
+
+import {TestHelper} from 'utils/test_helper';
+
+jest.mock('mattermost-redux/selectors/entities/users', () => {
+    const original = jest.requireActual('mattermost-redux/selectors/entities/users');
+    return {
+        ...original,
+        getCurrentUser: jest.fn(),
+        getUser: jest.fn(),
+    };
+});
+
+jest.mock('mattermost-redux/selectors/entities/general', () => {
+    const original = jest.requireActual('mattermost-redux/selectors/entities/general');
+    return {
+        ...original,
+        getConfig: jest.fn(),
+    };
+});
+
+const customStatus = {
+    emoji: 'speech_balloon',
+    text: 'speaking',
+};
+
+describe('getCustomStatus', () => {
+    const user = TestHelper.getUserMock();
+
+    it('should return empty object when there is no custom status', async () => {
+        const store = await configureStore();
+        getCurrentUser.mockReturnValue(user);
+        expect(getCustomStatus(store.getState(), '')).toStrictEqual({});
+    });
+
+    it('should return empty object when user with given id has no custom status set', async () => {
+        const store = await configureStore();
+        getUser.mockReturnValue(user);
+        expect(getCustomStatus(store.getState(), user.id)).toStrictEqual({});
+    });
+
+    it('should return customStatus object when there is custom status set', async () => {
+        const store = await configureStore();
+        user.props.customStatus = JSON.stringify(customStatus);
+        getCurrentUser.mockReturnValue(user);
+        expect(getCustomStatus(store.getState(), '')).toStrictEqual(customStatus);
+    });
+});
+
+describe('getRecentCustomStatuses', () => {
+    const user = TestHelper.getUserMock();
+
+    it('should return empty arr if there are no recent custom statuses', async () => {
+        const store = await configureStore();
+        getUser.mockReturnValue(user);
+        expect(getRecentCustomStatuses(store.getState(), user.id)).toStrictEqual([]);
+    });
+
+    it('should return arr of custom statuses if there are recent custom statuses', async () => {
+        const store = await configureStore();
+        user.props.recentCustomStatuses = JSON.stringify([customStatus]);
+        getUser.mockReturnValue(user);
+        expect(getRecentCustomStatuses(store.getState(), user.id)).toStrictEqual([customStatus]);
+    });
+});
+
+describe('isCustomStatusEnabled', () => {
+    const config = {
+        EnableCustomUserStatuses: 'true',
+    };
+
+    it('should return true if EnableCustomUserStatuses is true in the config', async () => {
+        const store = await configureStore();
+        expect(isCustomStatusEnabled(store.getState())).toBeFalsy();
+    });
+
+    it('should return true if EnableCustomUserStatuses is true in the config', async () => {
+        const store = await configureStore();
+        getConfig.mockReturnValue(config);
+        expect(isCustomStatusEnabled(store.getState())).toBeTruthy();
+    });
+});

--- a/selectors/views/custom_status.test.ts
+++ b/selectors/views/custom_status.test.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {getCurrentUser, getUser} from 'mattermost-redux/selectors/entities/users';
+
+import configureStore from 'store';
+import {getCustomStatus, getRecentCustomStatuses} from 'selectors/views/custom_status';
+
+import {TestHelper} from 'utils/test_helper';
+
+jest.mock('mattermost-redux/selectors/entities/users', () => {
+    const original = jest.requireActual('mattermost-redux/selectors/entities/users');
+    return {
+        ...original,
+        getCurrentUser: jest.fn(),
+        getUser: jest.fn(),
+    };
+});
+
+const customStatus = {
+    emoji: 'speech_balloon',
+    text: 'speaking',
+};
+
+describe('getCustomStatus', () => {
+    const user = TestHelper.getUserMock();
+
+    it('should return empty object when there is no custom status', async () => {
+        const store = await configureStore();
+        getCurrentUser.mockReturnValue(user);
+        expect(getCustomStatus(store.getState(), '')).toStrictEqual({});
+    });
+
+    it('should return empty object when user with given id has no custom status set', async () => {
+        const store = await configureStore();
+        getUser.mockReturnValue(user);
+        expect(getCustomStatus(store.getState(), user.id)).toStrictEqual({});
+    });
+
+    it('should return customStatus object when there is custom status set', async () => {
+        const store = await configureStore();
+        user.props.customStatus = JSON.stringify(customStatus);
+        getCurrentUser.mockReturnValue(user);
+        expect(getCustomStatus(store.getState(), '')).toStrictEqual(customStatus);
+    });
+});
+
+describe('getRecentCustomStatuses', () => {
+    const user = TestHelper.getUserMock();
+
+    it('should return empty arr if there are no recent custom statuses', async () => {
+        const store = await configureStore();
+        getUser.mockReturnValue(user);
+        expect(getRecentCustomStatuses(store.getState(), user.id)).toStrictEqual([]);
+    });
+
+    it('should return arr of custom statuses if there are recent custom statuses', async () => {
+        const store = await configureStore();
+        user.props.recentCustomStatuses = JSON.stringify([customStatus]);
+        getUser.mockReturnValue(user);
+        expect(getRecentCustomStatuses(store.getState(), user.id)).toStrictEqual([customStatus]);
+    });
+});

--- a/selectors/views/custom_status.ts
+++ b/selectors/views/custom_status.ts
@@ -21,5 +21,5 @@ export function isCustomStatusEnabled(state: GlobalState) {
     const config = getConfig(state);
 
     // TODO: add EnableCustomUserStatuses property in config.
-    return config.EnableCustomUserStatuses === 'true';
+    return config && config.EnableCustomUserStatuses === 'true';
 }

--- a/selectors/views/custom_status.ts
+++ b/selectors/views/custom_status.ts
@@ -19,7 +19,5 @@ export function getRecentCustomStatuses(state: GlobalState, userID: string) {
 
 export function isCustomStatusEnabled(state: GlobalState) {
     const config = getConfig(state);
-
-    // TODO: add EnableCustomUserStatuses property in config.
-    return config.EnableCustomUserStatuses === 'true';
+    return config && config.EnableCustomUserStatuses === 'true';
 }

--- a/selectors/views/custom_status.ts
+++ b/selectors/views/custom_status.ts
@@ -4,7 +4,6 @@ import {getCurrentUser, getUser} from 'mattermost-redux/selectors/entities/users
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {GlobalState} from 'types/store';
-import Constants from 'utils/constants';
 
 export function getCustomStatus(state: GlobalState, userID: string | undefined) {
     const user = userID ? getUser(state, userID) : getCurrentUser(state);
@@ -23,28 +22,4 @@ export function isCustomStatusEnabled(state: GlobalState) {
 
     // TODO: add EnableCustomUserStatuses property in config.
     return config.EnableCustomUserStatuses === 'true';
-}
-
-export function hasSetCustomStatusBefore(state: GlobalState, userID: string) {
-    const user = getUser(state, userID);
-    const userProps = user.props || {};
-    return Boolean(userProps.recentCustomStatuses);
-}
-
-export function hasClickedOnUpdateStatusBefore(state: GlobalState, userID: string) {
-    const user = getUser(state, userID);
-    const userProps = user.props;
-    if (!userProps) {
-        return false;
-    }
-    return userProps.initialProps === Constants.CustomStatusInitialProps.CLICK_ON_UPDATE_STATUS_FROM_POST;
-}
-
-export function hasClickedOnSetStatusBefore(state: GlobalState, userID: string) {
-    const user = getUser(state, userID);
-    const userProps = user.props;
-    if (!userProps) {
-        return false;
-    }
-    return userProps.initialProps === Constants.CustomStatusInitialProps.CLICK_ON_SET_STATUS;
 }

--- a/selectors/views/custom_status.ts
+++ b/selectors/views/custom_status.ts
@@ -19,7 +19,5 @@ export function getRecentCustomStatuses(state: GlobalState, userID: string) {
 
 export function isCustomStatusEnabled(state: GlobalState) {
     const config = getConfig(state);
-
-    // TODO: add EnableCustomUserStatuses property in config.
     return config && config.EnableCustomUserStatuses === 'true';
 }

--- a/selectors/views/custom_status.ts
+++ b/selectors/views/custom_status.ts
@@ -4,6 +4,7 @@ import {getCurrentUser, getUser} from 'mattermost-redux/selectors/entities/users
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {GlobalState} from 'types/store';
+import Constants from 'utils/constants';
 
 export function getCustomStatus(state: GlobalState, userID: string | undefined) {
     const user = userID ? getUser(state, userID) : getCurrentUser(state);
@@ -22,4 +23,28 @@ export function isCustomStatusEnabled(state: GlobalState) {
 
     // TODO: add EnableCustomUserStatuses property in config.
     return config.EnableCustomUserStatuses === 'true';
+}
+
+export function hasSetCustomStatusBefore(state: GlobalState, userID: string) {
+    const user = getUser(state, userID);
+    const userProps = user.props || {};
+    return Boolean(userProps.recentCustomStatuses);
+}
+
+export function hasClickedOnUpdateStatusBefore(state: GlobalState, userID: string) {
+    const user = getUser(state, userID);
+    const userProps = user.props;
+    if (!userProps) {
+        return false;
+    }
+    return userProps.initialProps === Constants.CustomStatusInitialProps.CLICK_ON_UPDATE_STATUS_FROM_POST;
+}
+
+export function hasClickedOnSetStatusBefore(state: GlobalState, userID: string) {
+    const user = getUser(state, userID);
+    const userProps = user.props;
+    if (!userProps) {
+        return false;
+    }
+    return userProps.initialProps === Constants.CustomStatusInitialProps.CLICK_ON_SET_STATUS;
 }

--- a/selectors/views/status_dropdown.test.ts
+++ b/selectors/views/status_dropdown.test.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {isStatusDropdownOpen} from 'selectors/views/status_dropdown';
+import {setStatusDropdown} from 'actions/views/status_dropdown';
+import configureStore from 'store';
+
+describe('status_dropdown selector', () => {
+    it('should return the isOpen value from the state', async () => {
+        const store = await configureStore();
+        expect(isStatusDropdownOpen(store.getState())).toBeFalsy();
+    });
+
+    it('should return true if statusDropdown in explicitly opened', async () => {
+        const store = await configureStore();
+        await store.dispatch(setStatusDropdown(true));
+        expect(isStatusDropdownOpen(store.getState())).toBeTruthy();
+    });
+});

--- a/selectors/views/status_dropdown.ts
+++ b/selectors/views/status_dropdown.ts
@@ -1,0 +1,7 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {GlobalState} from 'types/store';
+
+export function isStatusDropdownOpen(state: GlobalState) {
+    return state.views.statusDropdown.isOpen;
+}

--- a/selectors/views/status_dropdown.ts
+++ b/selectors/views/status_dropdown.ts
@@ -1,0 +1,7 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {GlobalState} from 'mattermost-redux/types/store';
+
+export function isStatusDropdownOpen(state: GlobalState) {
+    return state.views.statusDropdown.isOpen;
+}

--- a/selectors/views/status_dropdown.ts
+++ b/selectors/views/status_dropdown.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import {GlobalState} from 'mattermost-redux/types/store';
+import {GlobalState} from 'types/store';
 
 export function isStatusDropdownOpen(state: GlobalState) {
     return state.views.statusDropdown.isOpen;

--- a/types/store/custom_status.ts
+++ b/types/store/custom_status.ts
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-export type CustomStatus = {
-    emoji: string;
-    text: string;
+export type CustomStatusInitialisationStates = {
+    hasClickedSetStatusBefore: boolean;
 }

--- a/types/store/custom_status.ts
+++ b/types/store/custom_status.ts
@@ -1,11 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-export type CustomStatus = {
-    emoji: string;
-    text: string;
-}
-
 export type CustomStatusInitialisationStates = {
     hasClickedSetStatusBefore: boolean;
 }

--- a/types/store/custom_status.ts
+++ b/types/store/custom_status.ts
@@ -7,7 +7,5 @@ export type CustomStatus = {
 }
 
 export type CustomStatusInitialisationStates = {
-    hasClickedUpdateStatusBefore: boolean;
-    hasClickedSidebarHeaderFirstTime: boolean;
-    menuOpenedOnClick: string;
+    hasClickedSetStatusBefore: boolean;
 }

--- a/types/store/custom_status.ts
+++ b/types/store/custom_status.ts
@@ -6,7 +6,7 @@ export type CustomStatus = {
     text: string;
 }
 
-export type CustomStatusInitialProps = {
+export type CustomStatusInitialisationState = {
     hasClickedUpdateStatusBefore: boolean;
     hasClickedSidebarHeaderFirstTime: boolean;
     menuOpenedOnClick: string;

--- a/types/store/custom_status.ts
+++ b/types/store/custom_status.ts
@@ -1,13 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-export type CustomStatus = {
-    emoji: string;
-    text: string;
-}
-
 export type CustomStatusInitialisationStates = {
-    hasClickedUpdateStatusBefore: boolean;
-    hasClickedSidebarHeaderFirstTime: boolean;
-    menuOpenedOnClick: string;
+    hasOpenedSetCustomStatusModal: boolean;
 }

--- a/types/store/custom_status.ts
+++ b/types/store/custom_status.ts
@@ -5,3 +5,9 @@ export type CustomStatus = {
     emoji: string;
     text: string;
 }
+
+export type CustomStatusInitialProps = {
+    hasClickedUpdateStatusBefore: boolean;
+    hasClickedSidebarHeaderFirstTime: boolean;
+    menuOpenedOnClick: string;
+}

--- a/types/store/custom_status.ts
+++ b/types/store/custom_status.ts
@@ -6,7 +6,7 @@ export type CustomStatus = {
     text: string;
 }
 
-export type CustomStatusInitialisationState = {
+export type CustomStatusInitialisationStates = {
     hasClickedUpdateStatusBefore: boolean;
     hasClickedSidebarHeaderFirstTime: boolean;
     menuOpenedOnClick: string;

--- a/types/store/views.ts
+++ b/types/store/views.ts
@@ -137,4 +137,8 @@ export type ViewsState = {
     nextSteps: {
         show: boolean;
     };
+
+    statusDropdown: {
+        isOpen: boolean;
+    };
 };

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -881,13 +881,13 @@ export const ZoomSettings = {
     MAX_SCALE: 3.0,
 };
 
-export const CustomStatusInitialProps = {
+export const CustomStatusInitialisationState = {
     MENU_OPENED_BY_POST_HEADER: 'post_header',
     MENU_OPENED_BY_SIDEBAR_HEADER: 'sidebar_header',
 };
 
 export const Constants = {
-    CustomStatusInitialProps,
+    CustomStatusInitialisationState,
     SettingsTypes,
     JobTypes,
     Preferences,

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -881,13 +881,7 @@ export const ZoomSettings = {
     MAX_SCALE: 3.0,
 };
 
-export const CustomStatusInitialisationStates = {
-    MENU_OPENED_BY_POST_HEADER: 'post_header',
-    MENU_OPENED_BY_SIDEBAR_HEADER: 'sidebar_header',
-};
-
 export const Constants = {
-    CustomStatusInitialisationStates,
     SettingsTypes,
     JobTypes,
     Preferences,

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -882,8 +882,8 @@ export const ZoomSettings = {
 };
 
 export const CustomStatusInitialProps = {
-    CLICK_ON_UPDATE_STATUS_FROM_POST: 'click_on_update_status_from_post',
-    CLICK_ON_SIDEBAR_HEADER_DROPDOWN_ICON: 'click_on_sidebar_header_dropdown_icon',
+    MENU_OPENED_BY_POST_HEADER: 'post_header',
+    MENU_OPENED_BY_SIDEBAR_HEADER: 'sidebar_header',
 };
 
 export const Constants = {

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -161,6 +161,7 @@ export const ActionTypes = keyMirror({
 
     INCREMENT_EMOJI_PICKER_PAGE: null,
 
+    STATUS_DROPDOWN_TOGGLE: null,
     TOGGLE_LHS: null,
     OPEN_LHS: null,
     CLOSE_LHS: null,
@@ -880,7 +881,13 @@ export const ZoomSettings = {
     MAX_SCALE: 3.0,
 };
 
+export const CustomStatusInitialProps = {
+    CLICK_ON_SET_STATUS: 'click_on_set_status',
+    CLICK_ON_UPDATE_STATUS_FROM_POST: 'click_on_update_status_from_post',
+};
+
 export const Constants = {
+    CustomStatusInitialProps,
     SettingsTypes,
     JobTypes,
     Preferences,

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -161,6 +161,7 @@ export const ActionTypes = keyMirror({
 
     INCREMENT_EMOJI_PICKER_PAGE: null,
 
+    STATUS_DROPDOWN_TOGGLE: null,
     TOGGLE_LHS: null,
     OPEN_LHS: null,
     CLOSE_LHS: null,

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -882,8 +882,8 @@ export const ZoomSettings = {
 };
 
 export const CustomStatusInitialProps = {
-    CLICK_ON_SET_STATUS: 'click_on_set_status',
     CLICK_ON_UPDATE_STATUS_FROM_POST: 'click_on_update_status_from_post',
+    CLICK_ON_SIDEBAR_HEADER_DROPDOWN_ICON: 'click_on_sidebar_header_dropdown_icon',
 };
 
 export const Constants = {

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -881,13 +881,13 @@ export const ZoomSettings = {
     MAX_SCALE: 3.0,
 };
 
-export const CustomStatusInitialisationState = {
+export const CustomStatusInitialisationStates = {
     MENU_OPENED_BY_POST_HEADER: 'post_header',
     MENU_OPENED_BY_SIDEBAR_HEADER: 'sidebar_header',
 };
 
 export const Constants = {
-    CustomStatusInitialisationState,
+    CustomStatusInitialisationStates,
     SettingsTypes,
     JobTypes,
     Preferences,

--- a/utils/custom_status.ts
+++ b/utils/custom_status.ts
@@ -6,7 +6,7 @@ import {GlobalState} from 'types/store';
 
 import Constants from './constants';
 
-export function showPulsatingDot(state: GlobalState) {
+export function showCustomStatusPulsatingDot(state: GlobalState) {
     const user = getCurrentUser(state);
     const userProps = user.props;
     if (!(userProps && userProps.customStatusInitialisationState)) {
@@ -15,7 +15,7 @@ export function showPulsatingDot(state: GlobalState) {
 
     const initialState = userProps.customStatusInitialisationState ? JSON.parse(userProps.customStatusInitialisationState) : {};
     const hasClickedSidebarHeaderFirstTime = initialState?.hasClickedSidebarHeaderFirstTime;
-    const menuOpenedFromPostHeader = initialState?.menuOpenedOnClick === Constants.CustomStatusInitialisationState.MENU_OPENED_BY_POST_HEADER;
+    const menuOpenedFromPostHeader = initialState?.menuOpenedOnClick === Constants.CustomStatusInitialisationStates.MENU_OPENED_BY_POST_HEADER;
 
     return hasClickedSidebarHeaderFirstTime || menuOpenedFromPostHeader;
 }

--- a/utils/custom_status.ts
+++ b/utils/custom_status.ts
@@ -9,13 +9,13 @@ import Constants from './constants';
 export function showPulsatingDot(state: GlobalState) {
     const user = getCurrentUser(state);
     const userProps = user.props;
-    if (!userProps) {
+    if (!(userProps && userProps.customStatusInitialisationState)) {
         return true;
     }
 
-    const initialProps = userProps.initialProps ? JSON.parse(userProps.initialProps) : {};
-    const hasClickedSidebarHeaderFirstTime = initialProps?.hasClickedSidebarHeaderFirstTime;
-    const menuOpenedFromPostHeader = initialProps?.menuOpenedOnClick === Constants.CustomStatusInitialProps.MENU_OPENED_BY_POST_HEADER;
+    const initialState = userProps.customStatusInitialisationState ? JSON.parse(userProps.customStatusInitialisationState) : {};
+    const hasClickedSidebarHeaderFirstTime = initialState?.hasClickedSidebarHeaderFirstTime;
+    const menuOpenedFromPostHeader = initialState?.menuOpenedOnClick === Constants.CustomStatusInitialisationState.MENU_OPENED_BY_POST_HEADER;
 
     return hasClickedSidebarHeaderFirstTime || menuOpenedFromPostHeader;
 }
@@ -28,6 +28,6 @@ export function showUpdateStatusButton(state: GlobalState) {
     }
 
     const hasSetCustomStatusBefore = userProps && userProps.recentCustomStatuses;
-    const initialProps = userProps.initialProps ? JSON.parse(userProps.initialProps) : {};
-    return !(hasSetCustomStatusBefore || initialProps.hasClickedUpdateStatusBefore);
+    const initialState = userProps.customStatusInitialisationState ? JSON.parse(userProps.customStatusInitialisationState) : {};
+    return !(hasSetCustomStatusBefore || initialState.hasClickedUpdateStatusBefore);
 }

--- a/utils/custom_status.ts
+++ b/utils/custom_status.ts
@@ -4,9 +4,7 @@ import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
 import {GlobalState} from 'types/store';
 
-import Constants from './constants';
-
-export function showCustomStatusPulsatingDot(state: GlobalState) {
+export function showCustomStatusLinkAndPulsatingDot(state: GlobalState) {
     const user = getCurrentUser(state);
     const userProps = user.props;
     if (!(userProps && userProps.customStatusInitialisationState)) {
@@ -14,20 +12,5 @@ export function showCustomStatusPulsatingDot(state: GlobalState) {
     }
 
     const initialState = userProps.customStatusInitialisationState ? JSON.parse(userProps.customStatusInitialisationState) : {};
-    const hasClickedSidebarHeaderFirstTime = initialState?.hasClickedSidebarHeaderFirstTime;
-    const menuOpenedFromPostHeader = initialState?.menuOpenedOnClick === Constants.CustomStatusInitialisationStates.MENU_OPENED_BY_POST_HEADER;
-
-    return hasClickedSidebarHeaderFirstTime || menuOpenedFromPostHeader;
-}
-
-export function showUpdateStatusButton(state: GlobalState) {
-    const user = getCurrentUser(state);
-    const userProps = user.props;
-    if (!userProps) {
-        return true;
-    }
-
-    const hasSetCustomStatusBefore = userProps && userProps.recentCustomStatuses;
-    const initialState = userProps.customStatusInitialisationState ? JSON.parse(userProps.customStatusInitialisationState) : {};
-    return !(hasSetCustomStatusBefore || initialState.hasClickedUpdateStatusBefore);
+    return initialState.hasClickedSetStatusBefore === 'true';
 }

--- a/utils/custom_status.ts
+++ b/utils/custom_status.ts
@@ -4,7 +4,7 @@ import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
 import {GlobalState} from 'types/store';
 
-export function showCustomStatusLinkAndPulsatingDot(state: GlobalState) {
+export function showCustomStatusPulsatingDotAndPostHeader(state: GlobalState) {
     const user = getCurrentUser(state);
     const userProps = user.props;
     if (!(userProps && userProps.customStatusInitialisationState)) {
@@ -12,5 +12,5 @@ export function showCustomStatusLinkAndPulsatingDot(state: GlobalState) {
     }
 
     const initialState = userProps.customStatusInitialisationState ? JSON.parse(userProps.customStatusInitialisationState) : {};
-    return initialState.hasClickedSetStatusBefore === 'true';
+    return !(initialState && initialState.hasClickedSetStatusBefore);
 }

--- a/utils/custom_status.ts
+++ b/utils/custom_status.ts
@@ -1,6 +1,10 @@
-import { GlobalState } from "types/store";
-import { getCurrentUser } from 'mattermost-redux/selectors/entities/users';
-import Constants from "./constants";
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+
+import {GlobalState} from 'types/store';
+
+import Constants from './constants';
 
 export function showPulsatingDot(state: GlobalState) {
     const user = getCurrentUser(state);
@@ -10,8 +14,8 @@ export function showPulsatingDot(state: GlobalState) {
     }
 
     const hasClickedOnUpdateStatusBefore = userProps.initialProps === Constants.CustomStatusInitialProps.CLICK_ON_UPDATE_STATUS_FROM_POST;
-    
-    const hasClickedOnDropdownIconBefore =userProps.initialProps === Constants.CustomStatusInitialProps.CLICK_ON_SIDEBAR_HEADER_DROPDOWN_ICON;
+
+    const hasClickedOnDropdownIconBefore = userProps.initialProps === Constants.CustomStatusInitialProps.CLICK_ON_SIDEBAR_HEADER_DROPDOWN_ICON;
     return true;
 }
 

--- a/utils/custom_status.ts
+++ b/utils/custom_status.ts
@@ -1,0 +1,28 @@
+import { GlobalState } from "types/store";
+import { getCurrentUser } from 'mattermost-redux/selectors/entities/users';
+import Constants from "./constants";
+
+export function showPulsatingDot(state: GlobalState) {
+    const user = getCurrentUser(state);
+    const userProps = user.props;
+    if (!userProps) {
+        return true;
+    }
+
+    const hasClickedOnUpdateStatusBefore = userProps.initialProps === Constants.CustomStatusInitialProps.CLICK_ON_UPDATE_STATUS_FROM_POST;
+    
+    const hasClickedOnDropdownIconBefore =userProps.initialProps === Constants.CustomStatusInitialProps.CLICK_ON_SIDEBAR_HEADER_DROPDOWN_ICON;
+    return true;
+}
+
+export function showUpdateStatusButton(state: GlobalState) {
+    const user = getCurrentUser(state);
+    const userProps = user.props;
+    if (!userProps) {
+        return true;
+    }
+
+    const hasSetCustomStatusBefore = userProps && userProps.recentCustomStatuses;
+    const hasClickedOnUpdateStatusBefore = userProps.initialProps === Constants.CustomStatusInitialProps.CLICK_ON_UPDATE_STATUS_FROM_POST;
+    return !(hasSetCustomStatusBefore || hasClickedOnUpdateStatusBefore);
+}

--- a/utils/custom_status.ts
+++ b/utils/custom_status.ts
@@ -1,6 +1,10 @@
-import { GlobalState } from "types/store";
-import { getCurrentUser } from 'mattermost-redux/selectors/entities/users';
-import Constants from "./constants";
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+
+import {GlobalState} from 'types/store';
+
+import Constants from './constants';
 
 export function showPulsatingDot(state: GlobalState) {
     const user = getCurrentUser(state);
@@ -9,10 +13,11 @@ export function showPulsatingDot(state: GlobalState) {
         return true;
     }
 
-    const hasClickedOnUpdateStatusBefore = userProps.initialProps === Constants.CustomStatusInitialProps.CLICK_ON_UPDATE_STATUS_FROM_POST;
-    
-    const hasClickedOnDropdownIconBefore =userProps.initialProps === Constants.CustomStatusInitialProps.CLICK_ON_SIDEBAR_HEADER_DROPDOWN_ICON;
-    return true;
+    const initialProps = userProps.initialProps ? JSON.parse(userProps.initialProps) : {};
+    const hasClickedSidebarHeaderFirstTime = initialProps?.hasClickedSidebarHeaderFirstTime;
+    const menuOpenedFromPostHeader = initialProps?.menuOpenedOnClick === Constants.CustomStatusInitialProps.MENU_OPENED_BY_POST_HEADER;
+
+    return hasClickedSidebarHeaderFirstTime || menuOpenedFromPostHeader;
 }
 
 export function showUpdateStatusButton(state: GlobalState) {
@@ -23,6 +28,6 @@ export function showUpdateStatusButton(state: GlobalState) {
     }
 
     const hasSetCustomStatusBefore = userProps && userProps.recentCustomStatuses;
-    const hasClickedOnUpdateStatusBefore = userProps.initialProps === Constants.CustomStatusInitialProps.CLICK_ON_UPDATE_STATUS_FROM_POST;
-    return !(hasSetCustomStatusBefore || hasClickedOnUpdateStatusBefore);
+    const initialProps = userProps.initialProps ? JSON.parse(userProps.initialProps) : {};
+    return !(hasSetCustomStatusBefore || initialProps.hasClickedUpdateStatusBefore);
 }

--- a/utils/custom_status.ts
+++ b/utils/custom_status.ts
@@ -4,9 +4,7 @@ import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
 import {GlobalState} from 'types/store';
 
-import Constants from './constants';
-
-export function showCustomStatusPulsatingDot(state: GlobalState) {
+function showCustomStatusPulsatingDotAndPostHeader(state: GlobalState) {
     const user = getCurrentUser(state);
     const userProps = user.props;
     if (!(userProps && userProps.customStatusInitialisationState)) {
@@ -14,20 +12,13 @@ export function showCustomStatusPulsatingDot(state: GlobalState) {
     }
 
     const initialState = userProps.customStatusInitialisationState ? JSON.parse(userProps.customStatusInitialisationState) : {};
-    const hasClickedSidebarHeaderFirstTime = initialState?.hasClickedSidebarHeaderFirstTime;
-    const menuOpenedFromPostHeader = initialState?.menuOpenedOnClick === Constants.CustomStatusInitialisationStates.MENU_OPENED_BY_POST_HEADER;
-
-    return hasClickedSidebarHeaderFirstTime || menuOpenedFromPostHeader;
+    return !(initialState && initialState.hasOpenedSetCustomStatusModal);
 }
 
-export function showUpdateStatusButton(state: GlobalState) {
-    const user = getCurrentUser(state);
-    const userProps = user.props;
-    if (!userProps) {
-        return true;
-    }
+export function showStatusDropdownPulsatingDot(state: GlobalState) {
+    return showCustomStatusPulsatingDotAndPostHeader(state);
+}
 
-    const hasSetCustomStatusBefore = userProps && userProps.recentCustomStatuses;
-    const initialState = userProps.customStatusInitialisationState ? JSON.parse(userProps.customStatusInitialisationState) : {};
-    return !(hasSetCustomStatusBefore || initialState.hasClickedUpdateStatusBefore);
+export function showPostHeaderUpdateStatusButton(state: GlobalState) {
+    return showCustomStatusPulsatingDotAndPostHeader(state);
 }

--- a/utils/custom_status.ts
+++ b/utils/custom_status.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+
+import {GlobalState} from 'types/store';
+
+export function showCustomStatusPulsatingDotAndPostHeader(state: GlobalState) {
+    const user = getCurrentUser(state);
+    const userProps = user.props;
+    if (!(userProps && userProps.customStatusInitialisationState)) {
+        return true;
+    }
+
+    const initialState = userProps.customStatusInitialisationState ? JSON.parse(userProps.customStatusInitialisationState) : {};
+    return !(initialState && initialState.hasClickedSetStatusBefore);
+}

--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -1,26 +1,26 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import { createSelector } from 'reselect';
+import {createSelector} from 'reselect';
 
-import { Client4 } from 'mattermost-redux/client';
-import { haveIChannelPermission } from 'mattermost-redux/selectors/entities/roles';
-import { makeGetReactionsForPost, getPost } from 'mattermost-redux/selectors/entities/posts';
-import { get } from 'mattermost-redux/selectors/entities/preferences';
-import { makeGetDisplayName, getCurrentUserId } from 'mattermost-redux/selectors/entities/users';
-import { Permissions, Posts } from 'mattermost-redux/constants';
+import {Client4} from 'mattermost-redux/client';
+import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
+import {makeGetReactionsForPost, getPost} from 'mattermost-redux/selectors/entities/posts';
+import {get} from 'mattermost-redux/selectors/entities/preferences';
+import {makeGetDisplayName, getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {Permissions, Posts} from 'mattermost-redux/constants';
 import * as PostListUtils from 'mattermost-redux/utils/post_list';
-import { canEditPost as canEditPostRedux, isPostEphemeral } from 'mattermost-redux/utils/post_utils';
+import {canEditPost as canEditPostRedux, isPostEphemeral} from 'mattermost-redux/utils/post_utils';
 
-import { allAtMentions } from 'utils/text_formatting';
+import {allAtMentions} from 'utils/text_formatting';
 
-import { getEmojiMap } from 'selectors/emojis';
+import {getEmojiMap} from 'selectors/emojis';
 
-import Constants, { PostListRowListIds, Preferences } from 'utils/constants';
-import { formatWithRenderer } from 'utils/markdown';
+import Constants, {PostListRowListIds, Preferences} from 'utils/constants';
+import {formatWithRenderer} from 'utils/markdown';
 import MentionableRenderer from 'utils/markdown/mentionable_renderer';
 import * as Utils from 'utils/utils.jsx';
-import { isMobile } from 'utils/user_agent';
+import {isMobile} from 'utils/user_agent';
 
 import * as Emoticons from './emoticons';
 
@@ -77,9 +77,9 @@ export function canDeletePost(state, post, channel) {
     }
 
     if (isPostOwner(state, post)) {
-        return haveIChannelPermission(state, { channel: post.channel_id, team: channel && channel.team_id, permission: Permissions.DELETE_POST });
+        return haveIChannelPermission(state, {channel: post.channel_id, team: channel && channel.team_id, permission: Permissions.DELETE_POST});
     }
-    return haveIChannelPermission(state, { channel: post.channel_id, team: channel && channel.team_id, permission: Permissions.DELETE_OTHERS_POSTS });
+    return haveIChannelPermission(state, {channel: post.channel_id, team: channel && channel.team_id, permission: Permissions.DELETE_OTHERS_POSTS});
 }
 
 export function canEditPost(state, post, license, config, channel, userId) {
@@ -184,47 +184,47 @@ function canAutomaticallyCloseBackticks(message) {
         };
     }
 
-    return { allowSending: true };
+    return {allowSending: true};
 }
 
 function sendOnCtrlEnter(message, ctrlOrMetaKeyPressed, isSendMessageOnCtrlEnter, caretPosition) {
     const match = message.substring(0, caretPosition).match(Constants.TRIPLE_BACK_TICKS);
     if (isSendMessageOnCtrlEnter && ctrlOrMetaKeyPressed && (!match || match.length % 2 === 0)) {
-        return { allowSending: true };
+        return {allowSending: true};
     } else if (!isSendMessageOnCtrlEnter && (!match || match.length % 2 === 0)) {
-        return { allowSending: true };
+        return {allowSending: true};
     } else if (ctrlOrMetaKeyPressed && match && match.length % 2 !== 0) {
         return canAutomaticallyCloseBackticks(message);
     }
 
-    return { allowSending: false };
+    return {allowSending: false};
 }
 
 export function postMessageOnKeyPress(event, message, sendMessageOnCtrlEnter, sendCodeBlockOnCtrlEnter, now = 0, lastChannelSwitchAt = 0, caretPosition = 0) {
     if (!event) {
-        return { allowSending: false };
+        return {allowSending: false};
     }
 
     // Typing enter on mobile never sends.
     if (isMobile()) {
-        return { allowSending: false };
+        return {allowSending: false};
     }
 
     // Only ENTER sends, unless shift or alt key pressed.
     if (!Utils.isKeyPressed(event, Constants.KeyCodes.ENTER) || event.shiftKey || event.altKey) {
-        return { allowSending: false };
+        return {allowSending: false};
     }
 
     // Don't send if we just switched channels within a threshold.
     if (lastChannelSwitchAt > 0 && now > 0 && now - lastChannelSwitchAt <= CHANNEL_SWITCH_IGNORE_ENTER_THRESHOLD_MS) {
-        return { allowSending: false, ignoreKeyPress: true };
+        return {allowSending: false, ignoreKeyPress: true};
     }
 
     if (
         message.trim() === '' ||
         !(sendMessageOnCtrlEnter || sendCodeBlockOnCtrlEnter)
     ) {
-        return { allowSending: true };
+        return {allowSending: true};
     }
 
     const ctrlOrMetaKeyPressed = event.ctrlKey || event.metaKey;
@@ -235,7 +235,7 @@ export function postMessageOnKeyPress(event, message, sendMessageOnCtrlEnter, se
         return sendOnCtrlEnter(message, ctrlOrMetaKeyPressed, false, caretPosition);
     }
 
-    return { allowSending: false };
+    return {allowSending: false};
 }
 
 export function isErrorInvalidSlashCommand(error) {
@@ -344,7 +344,7 @@ export function makeCreateAriaLabelForPost() {
 }
 
 export function createAriaLabelForPost(post, author, isFlagged, reactions, intl, emojiMap) {
-    const { formatMessage, formatTime, formatDate } = intl;
+    const {formatMessage, formatTime, formatDate} = intl;
 
     let message = post.message || '';
     let match;
@@ -367,23 +367,23 @@ export function createAriaLabelForPost(post, author, isFlagged, reactions, intl,
             id: 'post.ariaLabel.replyMessage',
             defaultMessage: 'At {time} {date}, {authorName} replied, {message}',
         },
-            {
-                authorName: author,
-                time: formatTime(post.create_at),
-                date: formatDate(post.create_at, { weekday: 'long', month: 'long', day: 'numeric' }),
-                message,
-            });
+        {
+            authorName: author,
+            time: formatTime(post.create_at),
+            date: formatDate(post.create_at, {weekday: 'long', month: 'long', day: 'numeric'}),
+            message,
+        });
     } else {
         ariaLabel = formatMessage({
             id: 'post.ariaLabel.message',
             defaultMessage: 'At {time} {date}, {authorName} wrote, {message}',
         },
-            {
-                authorName: author,
-                time: formatTime(post.create_at),
-                date: formatDate(post.create_at, { weekday: 'long', month: 'long', day: 'numeric' }),
-                message,
-            });
+        {
+            authorName: author,
+            time: formatTime(post.create_at),
+            date: formatDate(post.create_at, {weekday: 'long', month: 'long', day: 'numeric'}),
+            message,
+        });
     }
 
     let attachmentCount = 0;
@@ -400,9 +400,9 @@ export function createAriaLabelForPost(post, author, isFlagged, reactions, intl,
                 id: 'post.ariaLabel.attachmentMultiple',
                 defaultMessage: ', {attachmentCount} attachments',
             },
-                {
-                    attachmentCount,
-                });
+            {
+                attachmentCount,
+            });
         } else {
             ariaLabel += formatMessage({
                 id: 'post.ariaLabel.attachment',
@@ -426,9 +426,9 @@ export function createAriaLabelForPost(post, author, isFlagged, reactions, intl,
                 id: 'post.ariaLabel.reactionMultiple',
                 defaultMessage: ', {reactionCount} reactions',
             },
-                {
-                    reactionCount: emojiNames.length,
-                });
+            {
+                reactionCount: emojiNames.length,
+            });
         } else {
             ariaLabel += formatMessage({
                 id: 'post.ariaLabel.reaction',
@@ -463,7 +463,7 @@ export function createAriaLabelForPost(post, author, isFlagged, reactions, intl,
 export function splitMessageBasedOnCaretPosition(caretPosition, message) {
     const firstPiece = message.substring(0, caretPosition);
     const lastPiece = message.substring(caretPosition, message.length);
-    return { firstPiece, lastPiece };
+    return {firstPiece, lastPiece};
 }
 
 export function getNewMessageIndex(postListIds) {
@@ -514,27 +514,29 @@ export function getPostFromId(state, id) {
 export function getCurrentUserLastGroupedPostId(state, postListIds) {
     //This function returns the first post id of the last post group by the current user
     let currentUserLastPost;
-    
-    postListIds.find(id=>{
+
+    postListIds.find((id) => {
         const post = getPostFromId(state, id);
         if (!post) {
-            if (currentUserLastPost) return true;
+            if (currentUserLastPost) {
+                return true;
+            }
             return false;
         }
 
         if (isPostOwner(state, post) && !isSystemMessage(post)) {
             if (currentUserLastPost) {
-                if (!areConsecutivePostsBySameUser(currentUserLastPost, post)){
+                if (!areConsecutivePostsBySameUser(currentUserLastPost, post)) {
                     return true;
                 }
             }
             currentUserLastPost = post;
-        }else{
-            return Boolean(currentUserLastPost)
+        } else {
+            return Boolean(currentUserLastPost);
         }
-        
-        return false;
-    })
 
-    return currentUserLastPost ? currentUserLastPost.id : "";
+        return false;
+    });
+
+    return currentUserLastPost ? currentUserLastPost.id : '';
 }

--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -515,28 +515,27 @@ export function getCurrentUserLastPostGroupFirstPostId(state, postListIds) {
     //This function returns the first post id of the last post group by the current user
     let currentUserLastPost;
 
-    postListIds.find((id) => {
+    for (let i = 0; i < postListIds.length; i++) {
+        const id = postListIds[i];
         const post = getPostFromId(state, id);
         if (!post) {
+            //if it is an combinedUserActivityPost, return if the currentUserLastPost is already set
             if (currentUserLastPost) {
-                return true;
+                return currentUserLastPost.id;
             }
-            return false;
+            continue;
         }
 
         if (isPostOwner(state, post) && !isSystemMessage(post)) {
-            if (currentUserLastPost) {
-                if (!areConsecutivePostsBySameUser(currentUserLastPost, post)) {
-                    return true;
-                }
+            if (currentUserLastPost && !areConsecutivePostsBySameUser(currentUserLastPost, post)) {
+                //currentUserLastPost is set and this post is not consecutive so the currentUserLastPost is the first post of the last postGroup
+                return currentUserLastPost.id;
             }
             currentUserLastPost = post;
-        } else {
-            return Boolean(currentUserLastPost);
+        } else if (currentUserLastPost) {
+            return currentUserLastPost.id;
         }
-
-        return false;
-    });
+    }
 
     return currentUserLastPost ? currentUserLastPost.id : '';
 }

--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -1,26 +1,26 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {createSelector} from 'reselect';
+import { createSelector } from 'reselect';
 
-import {Client4} from 'mattermost-redux/client';
-import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
-import {makeGetReactionsForPost} from 'mattermost-redux/selectors/entities/posts';
-import {get} from 'mattermost-redux/selectors/entities/preferences';
-import {makeGetDisplayName, getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import {Permissions, Posts} from 'mattermost-redux/constants';
+import { Client4 } from 'mattermost-redux/client';
+import { haveIChannelPermission } from 'mattermost-redux/selectors/entities/roles';
+import { makeGetReactionsForPost, getPost } from 'mattermost-redux/selectors/entities/posts';
+import { get } from 'mattermost-redux/selectors/entities/preferences';
+import { makeGetDisplayName, getCurrentUserId } from 'mattermost-redux/selectors/entities/users';
+import { Permissions, Posts } from 'mattermost-redux/constants';
 import * as PostListUtils from 'mattermost-redux/utils/post_list';
-import {canEditPost as canEditPostRedux, isPostEphemeral} from 'mattermost-redux/utils/post_utils';
+import { canEditPost as canEditPostRedux, isPostEphemeral } from 'mattermost-redux/utils/post_utils';
 
-import {allAtMentions} from 'utils/text_formatting';
+import { allAtMentions } from 'utils/text_formatting';
 
-import {getEmojiMap} from 'selectors/emojis';
+import { getEmojiMap } from 'selectors/emojis';
 
-import Constants, {PostListRowListIds, Preferences} from 'utils/constants';
-import {formatWithRenderer} from 'utils/markdown';
+import Constants, { PostListRowListIds, Preferences } from 'utils/constants';
+import { formatWithRenderer } from 'utils/markdown';
 import MentionableRenderer from 'utils/markdown/mentionable_renderer';
 import * as Utils from 'utils/utils.jsx';
-import {isMobile} from 'utils/user_agent';
+import { isMobile } from 'utils/user_agent';
 
 import * as Emoticons from './emoticons';
 
@@ -77,9 +77,9 @@ export function canDeletePost(state, post, channel) {
     }
 
     if (isPostOwner(state, post)) {
-        return haveIChannelPermission(state, {channel: post.channel_id, team: channel && channel.team_id, permission: Permissions.DELETE_POST});
+        return haveIChannelPermission(state, { channel: post.channel_id, team: channel && channel.team_id, permission: Permissions.DELETE_POST });
     }
-    return haveIChannelPermission(state, {channel: post.channel_id, team: channel && channel.team_id, permission: Permissions.DELETE_OTHERS_POSTS});
+    return haveIChannelPermission(state, { channel: post.channel_id, team: channel && channel.team_id, permission: Permissions.DELETE_OTHERS_POSTS });
 }
 
 export function canEditPost(state, post, license, config, channel, userId) {
@@ -184,47 +184,47 @@ function canAutomaticallyCloseBackticks(message) {
         };
     }
 
-    return {allowSending: true};
+    return { allowSending: true };
 }
 
 function sendOnCtrlEnter(message, ctrlOrMetaKeyPressed, isSendMessageOnCtrlEnter, caretPosition) {
     const match = message.substring(0, caretPosition).match(Constants.TRIPLE_BACK_TICKS);
     if (isSendMessageOnCtrlEnter && ctrlOrMetaKeyPressed && (!match || match.length % 2 === 0)) {
-        return {allowSending: true};
+        return { allowSending: true };
     } else if (!isSendMessageOnCtrlEnter && (!match || match.length % 2 === 0)) {
-        return {allowSending: true};
+        return { allowSending: true };
     } else if (ctrlOrMetaKeyPressed && match && match.length % 2 !== 0) {
         return canAutomaticallyCloseBackticks(message);
     }
 
-    return {allowSending: false};
+    return { allowSending: false };
 }
 
 export function postMessageOnKeyPress(event, message, sendMessageOnCtrlEnter, sendCodeBlockOnCtrlEnter, now = 0, lastChannelSwitchAt = 0, caretPosition = 0) {
     if (!event) {
-        return {allowSending: false};
+        return { allowSending: false };
     }
 
     // Typing enter on mobile never sends.
     if (isMobile()) {
-        return {allowSending: false};
+        return { allowSending: false };
     }
 
     // Only ENTER sends, unless shift or alt key pressed.
     if (!Utils.isKeyPressed(event, Constants.KeyCodes.ENTER) || event.shiftKey || event.altKey) {
-        return {allowSending: false};
+        return { allowSending: false };
     }
 
     // Don't send if we just switched channels within a threshold.
     if (lastChannelSwitchAt > 0 && now > 0 && now - lastChannelSwitchAt <= CHANNEL_SWITCH_IGNORE_ENTER_THRESHOLD_MS) {
-        return {allowSending: false, ignoreKeyPress: true};
+        return { allowSending: false, ignoreKeyPress: true };
     }
 
     if (
         message.trim() === '' ||
         !(sendMessageOnCtrlEnter || sendCodeBlockOnCtrlEnter)
     ) {
-        return {allowSending: true};
+        return { allowSending: true };
     }
 
     const ctrlOrMetaKeyPressed = event.ctrlKey || event.metaKey;
@@ -235,7 +235,7 @@ export function postMessageOnKeyPress(event, message, sendMessageOnCtrlEnter, se
         return sendOnCtrlEnter(message, ctrlOrMetaKeyPressed, false, caretPosition);
     }
 
-    return {allowSending: false};
+    return { allowSending: false };
 }
 
 export function isErrorInvalidSlashCommand(error) {
@@ -344,7 +344,7 @@ export function makeCreateAriaLabelForPost() {
 }
 
 export function createAriaLabelForPost(post, author, isFlagged, reactions, intl, emojiMap) {
-    const {formatMessage, formatTime, formatDate} = intl;
+    const { formatMessage, formatTime, formatDate } = intl;
 
     let message = post.message || '';
     let match;
@@ -367,23 +367,23 @@ export function createAriaLabelForPost(post, author, isFlagged, reactions, intl,
             id: 'post.ariaLabel.replyMessage',
             defaultMessage: 'At {time} {date}, {authorName} replied, {message}',
         },
-        {
-            authorName: author,
-            time: formatTime(post.create_at),
-            date: formatDate(post.create_at, {weekday: 'long', month: 'long', day: 'numeric'}),
-            message,
-        });
+            {
+                authorName: author,
+                time: formatTime(post.create_at),
+                date: formatDate(post.create_at, { weekday: 'long', month: 'long', day: 'numeric' }),
+                message,
+            });
     } else {
         ariaLabel = formatMessage({
             id: 'post.ariaLabel.message',
             defaultMessage: 'At {time} {date}, {authorName} wrote, {message}',
         },
-        {
-            authorName: author,
-            time: formatTime(post.create_at),
-            date: formatDate(post.create_at, {weekday: 'long', month: 'long', day: 'numeric'}),
-            message,
-        });
+            {
+                authorName: author,
+                time: formatTime(post.create_at),
+                date: formatDate(post.create_at, { weekday: 'long', month: 'long', day: 'numeric' }),
+                message,
+            });
     }
 
     let attachmentCount = 0;
@@ -400,9 +400,9 @@ export function createAriaLabelForPost(post, author, isFlagged, reactions, intl,
                 id: 'post.ariaLabel.attachmentMultiple',
                 defaultMessage: ', {attachmentCount} attachments',
             },
-            {
-                attachmentCount,
-            });
+                {
+                    attachmentCount,
+                });
         } else {
             ariaLabel += formatMessage({
                 id: 'post.ariaLabel.attachment',
@@ -426,9 +426,9 @@ export function createAriaLabelForPost(post, author, isFlagged, reactions, intl,
                 id: 'post.ariaLabel.reactionMultiple',
                 defaultMessage: ', {reactionCount} reactions',
             },
-            {
-                reactionCount: emojiNames.length,
-            });
+                {
+                    reactionCount: emojiNames.length,
+                });
         } else {
             ariaLabel += formatMessage({
                 id: 'post.ariaLabel.reaction',
@@ -463,7 +463,7 @@ export function createAriaLabelForPost(post, author, isFlagged, reactions, intl,
 export function splitMessageBasedOnCaretPosition(caretPosition, message) {
     const firstPiece = message.substring(0, caretPosition);
     const lastPiece = message.substring(caretPosition, message.length);
-    return {firstPiece, lastPiece};
+    return { firstPiece, lastPiece };
 }
 
 export function getNewMessageIndex(postListIds) {
@@ -485,4 +485,56 @@ export function makeGetReplyCount() {
             return postIds.map((id) => allPosts[id]).filter((post) => post && !isPostEphemeral(post)).length;
         },
     );
+}
+
+export function areConsecutivePostsBySameUser(post, previousPost) {
+    if (!(post && previousPost)) {
+        return false;
+    }
+    return post.user_id === previousPost.user_id && // The post is by the same user
+        post.create_at - previousPost.create_at <= Posts.POST_COLLAPSE_TIMEOUT && // And was within a short time period
+        !(post.props && post.props.from_webhook) && !(previousPost.props && previousPost.props.from_webhook) && // And neither is from a webhook
+        !isSystemMessage(post) && !isSystemMessage(previousPost); // And neither is a system message
+}
+
+export function getPostFromId(state, id) {
+    if (isIdNotPost(id)) {
+        //not a post
+        return null;
+    }
+
+    if (PostListUtils.isCombinedUserActivityPost(id)) {
+        // This is a combined post, so this cannot be a valid user post
+        return null;
+    }
+
+    return getPost(state, id);
+}
+
+export function getCurrentUserLastGroupedPostId(state, postListIds) {
+    //This function returns the first post id of the last post group by the current user
+    let currentUserLastPost;
+    
+    postListIds.find(id=>{
+        const post = getPostFromId(state, id);
+        if (!post) {
+            if (currentUserLastPost) return true;
+            return false;
+        }
+
+        if (isPostOwner(state, post) && !isSystemMessage(post)) {
+            console.log(post.message)
+            if (currentUserLastPost) {
+                if (!areConsecutivePostsBySameUser(currentUserLastPost, post)){
+                    return true;
+                }
+            }
+            currentUserLastPost = post;
+        }
+
+        return false;
+    })
+
+    console.log("================")
+    return currentUserLastPost ? currentUserLastPost.id : "";
 }

--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -523,18 +523,18 @@ export function getCurrentUserLastGroupedPostId(state, postListIds) {
         }
 
         if (isPostOwner(state, post) && !isSystemMessage(post)) {
-            console.log(post.message)
             if (currentUserLastPost) {
                 if (!areConsecutivePostsBySameUser(currentUserLastPost, post)){
                     return true;
                 }
             }
             currentUserLastPost = post;
+        }else{
+            return Boolean(currentUserLastPost)
         }
-
+        
         return false;
     })
 
-    console.log("================")
     return currentUserLastPost ? currentUserLastPost.id : "";
 }

--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -511,7 +511,7 @@ export function getPostFromId(state, id) {
     return getPost(state, id);
 }
 
-export function getCurrentUserLastGroupedPostId(state, postListIds) {
+export function getCurrentUserLastPostGroupFirstPostId(state, postListIds) {
     //This function returns the first post id of the last post group by the current user
     let currentUserLastPost;
 


### PR DESCRIPTION
#### Summary
- Create `pulsating-dot` component for status dropdown
- Pulsating dot is visible -
    - for the first time user opens the status dropdown when the custom-status feature is enabled.
    - when the user presses the post header component to open the status modal.

- Create the post header component to allow the current user to open the status dropdown.
- Post header is visible -
    - when the user has not set their custom status even once
    - till the time user has not clicked this button

#### Related Pull Requests


#### Screenshots

![image](https://user-images.githubusercontent.com/35728906/105486893-44faab00-5cd5-11eb-85db-3cf750fafdbd.png)
