### PR TITLE
Fixed custom status emoji tests

### DIFF
--- a/components/custom_status/custom_status_emoji.test.tsx
+++ b/components/custom_status/custom_status_emoji.test.tsx
@@ -7,10 +7,12 @@ import configureStore from 'redux-mock-store';
 import {Provider} from 'react-redux';
 
 import * as CustomStatusSelectors from 'selectors/views/custom_status';
+import * as EmojiSelectors from 'selectors/emojis';
 
 import CustomStatusEmoji from './custom_status_emoji';
 
 jest.mock('selectors/views/custom_status');
+jest.mock('selectors/emojis');
 
 describe('components/custom_status/custom_status_emoji', () => {
     const mockStore = configureStore();
@@ -20,6 +22,7 @@ describe('components/custom_status/custom_status_emoji', () => {
         return null;
     };
     (CustomStatusSelectors.makeGetCustomStatus as jest.Mock).mockReturnValue(getCustomStatus);
+    (EmojiSelectors.isCustomEmojiEnabled as jest.Mock).mockReturnValue(false);
     it('should match snapshot', () => {
         const wrapper = mount(<CustomStatusEmoji/>, {wrappingComponent: Provider, wrappingComponentProps: {store}});
         expect(wrapper).toMatchSnapshot();

--- a/components/custom_status/custom_status_emoji.tsx
+++ b/components/custom_status/custom_status_emoji.tsx
@@ -5,11 +5,11 @@ import {Tooltip} from 'react-bootstrap';
 import {useDispatch, useSelector} from 'react-redux';
 
 import {getCustomEmojis} from 'mattermost-redux/actions/emojis';
-import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import OverlayTrigger from 'components/overlay_trigger';
 import RenderEmoji from 'components/emoji/render_emoji';
 import {makeGetCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
+import {isCustomEmojiEnabled} from 'selectors/emojis';
 import {GlobalState} from 'types/store';
 import Constants from 'utils/constants';
 
@@ -27,9 +27,9 @@ const CustomStatusEmoji = (props: ComponentProps) => {
     const getCustomStatus = makeGetCustomStatus();
     const {emojiSize, emojiStyle, showTooltip, tooltipDirection, userID, onClick} = props;
 
-    const isCustomEmojiEnabled = useSelector((state: GlobalState) => getConfig(state).EnableCustomEmoji === 'true');
+    const customEmojiEnabled = useSelector(isCustomEmojiEnabled);
     useEffect(() => {
-        if (isCustomEmojiEnabled) {
+        if (customEmojiEnabled) {
             dispatch(getCustomEmojis());
         }
     }, [isCustomEmojiEnabled]);

--- a/selectors/emojis.js
+++ b/selectors/emojis.js
@@ -5,6 +5,7 @@ import {createSelector} from 'reselect';
 
 import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import LocalStorageStore from 'stores/local_storage_store';
 
@@ -35,3 +36,8 @@ export const getRecentEmojis = createSelector(
         return recentEmojis;
     },
 );
+
+export function isCustomEmojiEnabled(state) {
+    const config = getConfig(state);
+    return config && config.EnableCustomEmoji === 'true';
+}


### PR DESCRIPTION
Moved a selector from custom status emoji to selectors/emojis
Refactored custom status emoji to use the selector
Updated tests of custom status emoji

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has redux changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->