### PR TITLE
Added memoization in expiry time in some places

### DIFF
--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -230,6 +230,8 @@ class ChannelHeader extends React.PureComponent {
             <>
                 <CustomStatusEmoji
                     userID={this.props.dmUser.id}
+                    showTooltip={true}
+                    tooltipDirection='bottom'
                     emojiStyle={{
                         verticalAlign: 'top',
                         margin: '0 4px 1px',

--- a/components/custom_status/__snapshots__/custom_status_suggestion.test.tsx.snap
+++ b/components/custom_status/__snapshots__/custom_status_suggestion.test.tsx.snap
@@ -20,5 +20,13 @@ exports[`components/custom_status/custom_status_emoji should match snapshot 1`] 
     text=""
     tooltipDirection="top"
   />
+  <span
+    className="statusSuggestion__duration"
+  >
+    <FormattedMessage
+      defaultMessage="Don't clear"
+      id="expiry_dropdown.dont_clear"
+    />
+  </span>
 </div>
 `;

--- a/components/custom_status/__snapshots__/date_time_input.test.tsx.snap
+++ b/components/custom_status/__snapshots__/date_time_input.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/custom_status/date_time_input should match snapshot 1`] = `
+<DateTimeInputContainer
+  handleChange={[MockFunction]}
+  time={2021-05-03T14:53:39.127Z}
+  timezone="Australia/Sydney"
+/>
+`;

--- a/components/custom_status/__snapshots__/expiry_menu.test.tsx.snap
+++ b/components/custom_status/__snapshots__/expiry_menu.test.tsx.snap
@@ -1,0 +1,159 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/custom_status/expiry_menu should match snapshot 1`] = `
+<ExpiryMenu
+  expiry="dont_clear"
+  handleExpiryChange={[MockFunction]}
+>
+  <div
+    className="statusExpiry"
+  >
+    <div
+      className="statusExpiry__content"
+    >
+      <MenuWrapper
+        animationComponent={[Function]}
+        className="statusExpiry__menu"
+      >
+        <div
+          className="MenuWrapper statusExpiry__menu"
+          onClick={[Function]}
+        >
+          <span
+            className="expiry-wrapper expiry-selector"
+          >
+            <FormattedMessage
+              defaultMessage="Clear after"
+              id="expiry_dropdown.clear_after"
+            >
+              <span>
+                Clear after
+              </span>
+            </FormattedMessage>
+            : 
+            <span
+              className="expiry-value"
+            >
+              Don't clear
+            </span>
+            <span>
+              <i
+                aria-hidden="true"
+                className="fa fa-angle-down"
+              />
+            </span>
+          </span>
+          <MenuWrapperAnimation
+            show={false}
+          >
+            <CSSTransition
+              classNames="MenuWrapperAnimation"
+              enter={true}
+              exit={true}
+              in={false}
+              mountOnEnter={true}
+              timeout={80}
+              unmountOnExit={true}
+            >
+              <Transition
+                appear={false}
+                enter={true}
+                exit={true}
+                in={false}
+                mountOnEnter={true}
+                onEnter={[Function]}
+                onEntered={[Function]}
+                onEntering={[Function]}
+                onExit={[Function]}
+                onExited={[Function]}
+                onExiting={[Function]}
+                timeout={80}
+                unmountOnExit={true}
+              />
+            </CSSTransition>
+          </MenuWrapperAnimation>
+        </div>
+      </MenuWrapper>
+    </div>
+  </div>
+</ExpiryMenu>
+`;
+
+exports[`components/custom_status/expiry_menu should match snapshot with different props 1`] = `
+<ExpiryMenu
+  expiry="date_and_time"
+  handleExpiryChange={[MockFunction]}
+>
+  <div
+    className="statusExpiry"
+  >
+    <div
+      className="statusExpiry__content"
+    >
+      <MenuWrapper
+        animationComponent={[Function]}
+        className="statusExpiry__menu"
+      >
+        <div
+          className="MenuWrapper statusExpiry__menu"
+          onClick={[Function]}
+        >
+          <span
+            className="expiry-wrapper expiry-selector"
+          >
+            <FormattedMessage
+              defaultMessage="Clear after"
+              id="expiry_dropdown.clear_after"
+            >
+              <span>
+                Clear after
+              </span>
+            </FormattedMessage>
+            : 
+            <span
+              className="expiry-value"
+            >
+              Date and Time
+            </span>
+            <span>
+              <i
+                aria-hidden="true"
+                className="fa fa-angle-down"
+              />
+            </span>
+          </span>
+          <MenuWrapperAnimation
+            show={false}
+          >
+            <CSSTransition
+              classNames="MenuWrapperAnimation"
+              enter={true}
+              exit={true}
+              in={false}
+              mountOnEnter={true}
+              timeout={80}
+              unmountOnExit={true}
+            >
+              <Transition
+                appear={false}
+                enter={true}
+                exit={true}
+                in={false}
+                mountOnEnter={true}
+                onEnter={[Function]}
+                onEntered={[Function]}
+                onEntering={[Function]}
+                onExit={[Function]}
+                onExited={[Function]}
+                onExiting={[Function]}
+                timeout={80}
+                unmountOnExit={true}
+              />
+            </CSSTransition>
+          </MenuWrapperAnimation>
+        </div>
+      </MenuWrapper>
+    </div>
+  </div>
+</ExpiryMenu>
+`;

--- a/components/custom_status/custom_status.scss
+++ b/components/custom_status/custom_status.scss
@@ -255,7 +255,7 @@ span.emoticon[style]:hover {
 
 .dateTime {
     display: flex;
-    margin-top: 20px;
+    margin-top: 45px;
     width: calc(100% - 24px);
 
     & &__date {

--- a/components/custom_status/custom_status_emoji.test.tsx
+++ b/components/custom_status/custom_status_emoji.test.tsx
@@ -8,11 +8,13 @@ import {Provider} from 'react-redux';
 
 import * as CustomStatusSelectors from 'selectors/views/custom_status';
 import * as EmojiSelectors from 'selectors/emojis';
+import * as GeneralSelectors from 'selectors/general';
 
 import CustomStatusEmoji from './custom_status_emoji';
 
 jest.mock('selectors/views/custom_status');
 jest.mock('selectors/emojis');
+jest.mock('selectors/general');
 
 describe('components/custom_status/custom_status_emoji', () => {
     const mockStore = configureStore();
@@ -20,6 +22,7 @@ describe('components/custom_status/custom_status_emoji', () => {
 
     (CustomStatusSelectors.getCustomStatus as jest.Mock).mockReturnValue(null);
     (EmojiSelectors.isCustomEmojiEnabled as jest.Mock).mockReturnValue(false);
+    (GeneralSelectors.getCurrentUserTimezone as jest.Mock).mockReturnValue('Australia/Sydney');
     it('should match snapshot', () => {
         const wrapper = mount(<CustomStatusEmoji/>, {wrappingComponent: Provider, wrappingComponentProps: {store}});
         expect(wrapper).toMatchSnapshot();

--- a/components/custom_status/custom_status_emoji.tsx
+++ b/components/custom_status/custom_status_emoji.tsx
@@ -6,12 +6,12 @@ import {useSelector} from 'react-redux';
 
 import OverlayTrigger from 'components/overlay_trigger';
 import RenderEmoji from 'components/emoji/render_emoji';
+import {CustomStatusDuration} from 'mattermost-redux/types/users';
+import {getCurrentUserTimezone} from 'selectors/general';
 import {getCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
 import {GlobalState} from 'types/store';
 import Constants from 'utils/constants';
 import {displayExpiryTime} from 'utils/custom_status';
-import {CustomStatusDuration} from 'mattermost-redux/types/users';
-import {getCurrentUserTimezone} from 'selectors/general';
 
 interface ComponentProps {
     emojiSize?: number;

--- a/components/custom_status/custom_status_emoji.tsx
+++ b/components/custom_status/custom_status_emoji.tsx
@@ -31,12 +31,10 @@ const CustomStatusEmoji = (props: ComponentProps) => {
     });
     const timezone = useSelector(getCurrentUserTimezone);
     const expiryText = useCallback(() => {
-        if (customStatus.expires_at && customStatus.duration !== CustomStatusDuration.DONT_CLEAR) {
-            displayExpiryTime(customStatus.expires_at, timezone);
-        }
-    }, [customStatus.expires_at, timezone]);
+        return customStatus?.expires_at && customStatus.duration !== CustomStatusDuration.DONT_CLEAR && displayExpiryTime(customStatus.expires_at, timezone);
+    }, [customStatus?.expires_at, timezone]);
 
-    if (!(customStatusEnabled && customStatus && customStatus.emoji)) {
+    if (!(customStatusEnabled && customStatus?.emoji)) {
         return null;
     }
 
@@ -79,7 +77,8 @@ const CustomStatusEmoji = (props: ComponentProps) => {
                     {customStatus.expires_at && customStatus.duration !== CustomStatusDuration.DONT_CLEAR &&
                         <div>
                             <span>
-                                {`Until ${expiryText}`}
+                                {'Until '}
+                                {expiryText()}
                             </span>
                         </div>
                     }

--- a/components/custom_status/custom_status_emoji.tsx
+++ b/components/custom_status/custom_status_emoji.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import React, {useCallback} from 'react';
+import React from 'react';
 import {Tooltip} from 'react-bootstrap';
 import {useSelector} from 'react-redux';
 
@@ -11,7 +11,8 @@ import {getCurrentUserTimezone} from 'selectors/general';
 import {getCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
 import {GlobalState} from 'types/store';
 import Constants from 'utils/constants';
-import {displayExpiryTime} from 'utils/custom_status';
+
+import ExpiryTime from './expiry_time';
 
 interface ComponentProps {
     emojiSize?: number;
@@ -30,9 +31,6 @@ const CustomStatusEmoji = (props: ComponentProps) => {
         return getCustomStatus(state, userID);
     });
     const timezone = useSelector(getCurrentUserTimezone);
-    const expiryText = useCallback(() => {
-        return customStatus?.expires_at && customStatus.duration !== CustomStatusDuration.DONT_CLEAR && displayExpiryTime(customStatus.expires_at, timezone);
-    }, [customStatus?.expires_at, timezone]);
 
     if (!(customStatusEnabled && customStatus?.emoji)) {
         return null;
@@ -78,7 +76,10 @@ const CustomStatusEmoji = (props: ComponentProps) => {
                         <div>
                             <span>
                                 {'Until '}
-                                {expiryText()}
+                                <ExpiryTime
+                                    time={customStatus.expires_at}
+                                    timezone={timezone}
+                                />
                             </span>
                         </div>
                     }

--- a/components/custom_status/custom_status_modal.tsx
+++ b/components/custom_status/custom_status_modal.tsx
@@ -80,22 +80,22 @@ const defaultDuration = CustomStatusDuration.FOUR_HOURS;
 
 const CustomStatusModal: React.FC<Props> = (props: Props) => {
     const dispatch = useDispatch();
-    const currentCustomStatus = useSelector(getCustomStatus) || {};
+    const currentCustomStatus = useSelector(getCustomStatus);
     const recentCustomStatuses = useSelector(getRecentCustomStatuses);
     const customStatusControlRef = useRef<HTMLDivElement>(null);
     const {formatMessage} = useIntl();
     const [showEmojiPicker, setShowEmojiPicker] = useState<boolean>(false);
-    const [text, setText] = useState<string>(currentCustomStatus.text || '');
-    const [emoji, setEmoji] = useState<string>(currentCustomStatus.emoji || '');
-    const [expiry, setExpiry] = useState<CustomStatusDuration>(currentCustomStatus.duration || defaultDuration);
+    const [text, setText] = useState<string>(currentCustomStatus?.text || '');
+    const [emoji, setEmoji] = useState<string>(currentCustomStatus?.emoji || '');
+    const [expiry, setExpiry] = useState<CustomStatusDuration>(currentCustomStatus?.duration || defaultDuration);
     const isStatusSet = emoji || text;
-    const isCurrentCustomStatusSet = currentCustomStatus.text || currentCustomStatus.emoji;
+    const isCurrentCustomStatusSet = currentCustomStatus?.text || currentCustomStatus?.emoji;
     const firstTimeModalOpened = useSelector(showStatusDropdownPulsatingDot);
     const timezone = useSelector(getCurrentUserTimezone);
 
     const currentTime = timezone ? getCurrentDateAndTimeForTimezone(timezone) : new Date();
     let initialCustomExpiryTime: Date = getRoundedTime(currentTime);
-    if (currentCustomStatus.duration === CustomStatusDuration.DATE_AND_TIME && currentCustomStatus.expires_at) {
+    if (currentCustomStatus?.duration === CustomStatusDuration.DATE_AND_TIME && currentCustomStatus?.expires_at) {
         initialCustomExpiryTime = new Date(currentCustomStatus.expires_at);
     }
     const [customExpiryTime, setCustomExpiryTime] = useState<Date>(initialCustomExpiryTime);
@@ -177,12 +177,12 @@ const CustomStatusModal: React.FC<Props> = (props: Props) => {
         setExpiry(defaultDuration);
     };
 
-    let disableSetStatus = (currentCustomStatus.text === text && currentCustomStatus.emoji === emoji) ||
+    let disableSetStatus = (currentCustomStatus?.text === text && currentCustomStatus.emoji === emoji) ||
         (text === '' && emoji === '') || (text.length > Constants.CUSTOM_STATUS_TEXT_CHARACTER_LIMIT);
 
     disableSetStatus = Boolean(disableSetStatus &&
-        ((expiry !== CustomStatusDuration.DATE_AND_TIME && currentCustomStatus.duration === expiry) ||
-            (expiry === CustomStatusDuration.DATE_AND_TIME && currentCustomStatus.expires_at && customExpiryTime.getTime() === new Date(currentCustomStatus.expires_at).getTime())));
+        ((expiry !== CustomStatusDuration.DATE_AND_TIME && currentCustomStatus?.duration === expiry) ||
+            (expiry === CustomStatusDuration.DATE_AND_TIME && currentCustomStatus?.expires_at && customExpiryTime.getTime() === new Date(currentCustomStatus.expires_at).getTime())));
 
     const handleSuggestionClick = (status: UserCustomStatus) => {
         setEmoji(status.emoji);

--- a/components/custom_status/custom_status_modal.tsx
+++ b/components/custom_status/custom_status_modal.tsx
@@ -177,13 +177,6 @@ const CustomStatusModal: React.FC<Props> = (props: Props) => {
         setExpiry(defaultDuration);
     };
 
-    let disableSetStatus = (currentCustomStatus?.text === text && currentCustomStatus.emoji === emoji) ||
-        (text === '' && emoji === '') || (text.length > Constants.CUSTOM_STATUS_TEXT_CHARACTER_LIMIT);
-
-    disableSetStatus = Boolean(disableSetStatus &&
-        ((expiry !== CustomStatusDuration.DATE_AND_TIME && currentCustomStatus?.duration === expiry) ||
-            (expiry === CustomStatusDuration.DATE_AND_TIME && currentCustomStatus?.expires_at && customExpiryTime.getTime() === new Date(currentCustomStatus.expires_at).getTime())));
-
     const handleSuggestionClick = (status: UserCustomStatus) => {
         setEmoji(status.emoji);
         setText(status.text);
@@ -253,14 +246,18 @@ const CustomStatusModal: React.FC<Props> = (props: Props) => {
     };
 
     const areSelectedAndSetStatusSame = currentCustomStatus?.emoji === emoji && currentCustomStatus?.text === text && expiry === currentCustomStatus?.duration;
+
+    const isExpirySame = Boolean(currentCustomStatus?.expires_at && customExpiryTime.getTime() === new Date(currentCustomStatus.expires_at).getTime());
+
+    const disableSetStatus = emoji === '' || text.length > Constants.CUSTOM_STATUS_TEXT_CHARACTER_LIMIT || (areSelectedAndSetStatusSame && (expiry !== CustomStatusDuration.DATE_AND_TIME || isExpirySame));
+
     const showSuggestions = !isStatusSet || areSelectedAndSetStatusSame;
-    const showExpiryDropdown = !showSuggestions || areSelectedAndSetStatusSame;
     const showDateAndTimeField = !showSuggestions && expiry === CustomStatusDuration.DATE_AND_TIME;
 
     const suggestion = (
         <div
             className='statusSuggestion'
-            style={{marginTop: showExpiryDropdown ? 44 : 8}}
+            style={{marginTop: isStatusSet ? 44 : 8}}
         >
             <div className='statusSuggestion__content'>
                 {recentCustomStatuses.length > 0 && recentStatuses}
@@ -350,7 +347,7 @@ const CustomStatusModal: React.FC<Props> = (props: Props) => {
                         timezone={timezone}
                     />
                 )}
-                {showExpiryDropdown && (
+                {isStatusSet && (
                     <ExpiryMenu
                         expiry={expiry}
                         handleExpiryChange={handleExpiryChange}

--- a/components/custom_status/custom_status_suggestion.tsx
+++ b/components/custom_status/custom_status_suggestion.tsx
@@ -7,8 +7,8 @@ import {FormattedMessage} from 'react-intl';
 import {UserCustomStatus} from 'mattermost-redux/types/users';
 
 import OverlayTrigger from 'components/overlay_trigger';
-import Constants, {durationValues} from 'utils/constants';
 import RenderEmoji from 'components/emoji/render_emoji';
+import Constants, {durationValues} from 'utils/constants';
 
 import CustomStatusText from './custom_status_text';
 

--- a/components/custom_status/date_time_input.test.tsx
+++ b/components/custom_status/date_time_input.test.tsx
@@ -1,0 +1,34 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {shallow} from 'enzyme';
+import React from 'react';
+import configureStore from 'redux-mock-store';
+import {Provider} from 'react-redux';
+
+import {General} from 'mattermost-redux/constants';
+import * as i18Selectors from 'selectors/i18n';
+
+import DateTimeInput from './date_time_input';
+
+jest.mock('selectors/i18n');
+
+describe('components/custom_status/date_time_input', () => {
+    const mockStore = configureStore();
+    const store = mockStore({});
+
+    (i18Selectors.getCurrentLocale as jest.Mock).mockReturnValue(General.DEFAULT_LOCALE);
+    const baseProps = {
+        time: new Date('2021-05-03T14:53:39.127Z'),
+        handleChange: jest.fn(),
+        timezone: 'Australia/Sydney',
+    };
+
+    it('should match snapshot', () => {
+        const wrapper = shallow(
+            <Provider store={store}>
+                <DateTimeInput {...baseProps}/>
+            </Provider>,
+        );
+        expect(wrapper.dive()).toMatchSnapshot();
+    });
+});

--- a/components/custom_status/date_time_input.tsx
+++ b/components/custom_status/date_time_input.tsx
@@ -7,13 +7,13 @@ import {DayModifiers, NavbarElementProps} from 'react-day-picker';
 
 import moment from 'moment-timezone';
 
-import {localizeMessage} from 'utils/utils';
-import {getCurrentLocale} from 'selectors/i18n';
 import MenuWrapper from 'components/widgets/menu/menu_wrapper';
 import Menu from 'components/widgets/menu/menu';
-import {Constants} from 'utils/constants';
 import Timestamp from 'components/timestamp';
+import {getCurrentLocale} from 'selectors/i18n';
+import {Constants} from 'utils/constants';
 import {getCurrentDateAndTimeForTimezone} from 'utils/timezone';
+import {localizeMessage} from 'utils/utils';
 
 const Navbar: React.FC<Partial<NavbarElementProps>> = (navbarProps: Partial<NavbarElementProps>) => {
     const {

--- a/components/custom_status/expiry_menu.test.tsx
+++ b/components/custom_status/expiry_menu.test.tsx
@@ -1,0 +1,27 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import React from 'react';
+
+import {mountWithIntl} from 'tests/helpers/intl-test-helper';
+
+import {CustomStatusDuration} from 'mattermost-redux/types/users';
+
+import ExpiryMenu from './expiry_menu';
+
+describe('components/custom_status/expiry_menu', () => {
+    const baseProps = {
+        expiry: CustomStatusDuration.DONT_CLEAR,
+        handleExpiryChange: jest.fn(),
+    };
+
+    it('should match snapshot', () => {
+        const wrapper = mountWithIntl(<ExpiryMenu {...baseProps}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should match snapshot with different props', () => {
+        baseProps.expiry = CustomStatusDuration.DATE_AND_TIME;
+        const wrapper = mountWithIntl(<ExpiryMenu {...baseProps}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/components/custom_status/expiry_menu.tsx
+++ b/components/custom_status/expiry_menu.tsx
@@ -14,7 +14,7 @@ type ExpiryMenuItem = {
 }
 
 type Props = {
-    expiry: string;
+    expiry: CustomStatusDuration;
     handleExpiryChange: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>, expiryValue: CustomStatusDuration) => void;
 }
 
@@ -31,7 +31,7 @@ const {
 const ExpiryMenu: React.FC<Props> = (props: Props) => {
     const {expiry, handleExpiryChange} = props;
     const {formatMessage} = useIntl();
-    const expiryMenuItems: { [key: string]: ExpiryMenuItem } = {
+    const expiryMenuItems: { [key in CustomStatusDuration]: ExpiryMenuItem; } = {
         [DONT_CLEAR]: {
             text: formatMessage(durationValues[DONT_CLEAR]),
             value: formatMessage(durationValues[DONT_CLEAR]),
@@ -91,9 +91,9 @@ const ExpiryMenu: React.FC<Props> = (props: Props) => {
                             {Object.keys(expiryMenuItems).map((item) => (
                                 <Menu.ItemAction
                                     key={item}
-                                    onClick={(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => handleExpiryChange(event, item)}
-                                    ariaLabel={expiryMenuItems[item].text.toLowerCase()}
-                                    text={expiryMenuItems[item].text}
+                                    onClick={(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => handleExpiryChange(event, item as CustomStatusDuration)}
+                                    ariaLabel={expiryMenuItems[item as CustomStatusDuration].text.toLowerCase()}
+                                    text={expiryMenuItems[item as CustomStatusDuration].text}
                                     id={`expiry_menu_${item}`}
                                 />
                             ))}

--- a/components/custom_status/expiry_time.tsx
+++ b/components/custom_status/expiry_time.tsx
@@ -6,14 +6,19 @@ import moment from 'moment-timezone';
 
 import Timestamp, {RelativeRanges} from 'components/timestamp';
 
-import {getCurrentDateAndTimeForTimezone} from './timezone';
+import {getCurrentDateAndTimeForTimezone} from 'utils/timezone';
 
 const CUSTOM_STATUS_EXPIRY_RANGES = [
     RelativeRanges.TODAY_TITLE_CASE,
     RelativeRanges.TOMORROW_TITLE_CASE,
 ];
 
-export function displayExpiryTime(time: string, timezone?: string) {
+interface Props {
+    time: string;
+    timezone?: string;
+}
+
+const ExpiryTime = ({time, timezone}: Props) => {
     const currentTime = timezone ? getCurrentDateAndTimeForTimezone(timezone) : new Date();
     const timestampProps: { [key: string]: any } = {
         value: time,
@@ -33,4 +38,6 @@ export function displayExpiryTime(time: string, timezone?: string) {
             {...timestampProps}
         />
     );
-}
+};
+
+export default React.memo(ExpiryTime);

--- a/components/profile_popover/profile_popover.jsx
+++ b/components/profile_popover/profile_popover.jsx
@@ -27,9 +27,8 @@ import SharedUserIndicator from 'components/shared_user_indicator.tsx';
 import CustomStatusEmoji from 'components/custom_status/custom_status_emoji';
 import CustomStatusModal from 'components/custom_status/custom_status_modal';
 import CustomStatusText from 'components/custom_status/custom_status_text';
+import ExpiryTime from 'components/custom_status/expiry_time';
 import {CustomStatusDuration} from 'mattermost-redux/types/users';
-import {memoizeResult} from 'mattermost-redux/utils/helpers';
-import {displayExpiryTime} from 'utils/custom_status';
 
 import './profile_popover.scss';
 
@@ -156,7 +155,6 @@ class ProfilePopover extends React.PureComponent {
 
     constructor(props) {
         super(props);
-        this.displayExpiryTime = memoizeResult(displayExpiryTime);
         this.state = {
             loadingDMChannel: -1,
         };
@@ -301,7 +299,10 @@ class ProfilePopover extends React.PureComponent {
             expiryContent = customStatusSet && customStatus.expires_at && customStatus.duration !== CustomStatusDuration.DONT_CLEAR && (
                 <span>
                     {' (Until '}
-                    {this.displayExpiryTime(customStatus.expires_at, this.props.timezone)}
+                    <ExpiryTime
+                        time={customStatus.expires_at}
+                        timezone={this.props.timezone}
+                    />
                     {')'}
                 </span>
             );

--- a/components/profile_popover/profile_popover.jsx
+++ b/components/profile_popover/profile_popover.jsx
@@ -27,10 +27,11 @@ import SharedUserIndicator from 'components/shared_user_indicator.tsx';
 import CustomStatusEmoji from 'components/custom_status/custom_status_emoji';
 import CustomStatusModal from 'components/custom_status/custom_status_modal';
 import CustomStatusText from 'components/custom_status/custom_status_text';
+import {CustomStatusDuration} from 'mattermost-redux/types/users';
+import {memoizeResult} from 'mattermost-redux/utils/helpers';
+import {displayExpiryTime} from 'utils/custom_status';
 
 import './profile_popover.scss';
-import {displayExpiryTime} from 'utils/custom_status';
-import {CustomStatusDuration} from 'mattermost-redux/types/users';
 
 /**
  * The profile popover, or hovercard, that appears with user information when clicking
@@ -155,6 +156,7 @@ class ProfilePopover extends React.PureComponent {
 
     constructor(props) {
         super(props);
+        this.displayExpiryTime = memoizeResult(displayExpiryTime);
         this.state = {
             loadingDMChannel: -1,
         };
@@ -299,7 +301,7 @@ class ProfilePopover extends React.PureComponent {
             expiryContent = customStatusSet && customStatus.expires_at && customStatus.duration !== CustomStatusDuration.DONT_CLEAR && (
                 <span>
                     {' (Until '}
-                    {displayExpiryTime(customStatus.expires_at, this.props.timezone)}
+                    {this.displayExpiryTime(customStatus.expires_at, this.props.timezone)}
                     {')'}
                 </span>
             );

--- a/components/status_dropdown/status_dropdown.jsx
+++ b/components/status_dropdown/status_dropdown.jsx
@@ -23,9 +23,8 @@ import StatusDndIcon from 'components/widgets/icons/status_dnd_icon';
 import StatusOfflineIcon from 'components/widgets/icons/status_offline_icon';
 import OverlayTrigger from 'components/overlay_trigger';
 import CustomStatusText from 'components/custom_status/custom_status_text';
+import ExpiryTime from 'components/custom_status/expiry_time';
 import {CustomStatusDuration} from 'mattermost-redux/types/users';
-import {memoizeResult} from 'mattermost-redux/utils/helpers';
-import {displayExpiryTime} from 'utils/custom_status';
 
 import './status_dropdown.scss';
 
@@ -54,11 +53,6 @@ export default class StatusDropdown extends React.PureComponent {
         profilePicture: '',
         status: UserStatuses.OFFLINE,
         customStatus: {},
-    }
-
-    constructor(props) {
-        super(props);
-        this.displayExpiryTime = memoizeResult(displayExpiryTime);
     }
 
     isUserOutOfOffice = () => {
@@ -188,7 +182,10 @@ export default class StatusDropdown extends React.PureComponent {
             (
                 <span className='custom_status__expiry MenuItem__help-text'>
                     {'(Until '}
-                    {this.displayExpiryTime(customStatus.expires_at, this.props.timezone)}
+                    <ExpiryTime
+                        time={customStatus.expires_at}
+                        timezone={this.props.timezone}
+                    />
                     {')'}
                 </span>
             );

--- a/components/status_dropdown/status_dropdown.jsx
+++ b/components/status_dropdown/status_dropdown.jsx
@@ -24,6 +24,7 @@ import StatusOfflineIcon from 'components/widgets/icons/status_offline_icon';
 import OverlayTrigger from 'components/overlay_trigger';
 import CustomStatusText from 'components/custom_status/custom_status_text';
 import {CustomStatusDuration} from 'mattermost-redux/types/users';
+import {memoizeResult} from 'mattermost-redux/utils/helpers';
 import {displayExpiryTime} from 'utils/custom_status';
 
 import './status_dropdown.scss';
@@ -53,6 +54,11 @@ export default class StatusDropdown extends React.PureComponent {
         profilePicture: '',
         status: UserStatuses.OFFLINE,
         customStatus: {},
+    }
+
+    constructor(props) {
+        super(props);
+        this.displayExpiryTime = memoizeResult(displayExpiryTime);
     }
 
     isUserOutOfOffice = () => {
@@ -182,7 +188,7 @@ export default class StatusDropdown extends React.PureComponent {
             (
                 <span className='custom_status__expiry MenuItem__help-text'>
                     {'(Until '}
-                    {displayExpiryTime(customStatus.expires_at, this.props.timezone)}
+                    {this.displayExpiryTime(customStatus.expires_at, this.props.timezone)}
                     {')'}
                 </span>
             );

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -5,6 +5,8 @@ import keyMirror from 'key-mirror';
 
 import Permissions from 'mattermost-redux/constants/permissions';
 
+import {CustomStatusDuration} from 'mattermost-redux/types/users';
+
 import * as PostListUtils from 'mattermost-redux/utils/post_list';
 
 import audioIcon from 'images/icons/audio.svg';
@@ -26,7 +28,6 @@ import mattermostDarkThemeImage from 'images/themes/mattermost_dark.png';
 import defaultThemeImage from 'images/themes/organization.png';
 import windows10ThemeImage from 'images/themes/windows_dark.png';
 import logoWebhook from 'images/webhook_icon.jpg';
-import {CustomStatusDuration} from 'mattermost-redux/types/users';
 
 import {t} from 'utils/i18n';
 


### PR DESCRIPTION
Added memoization in status dropdown and profile popover
Added logic to show tooltip in custom status emoji in channel header
Refactored some code in custom status emoji and custom status selector
Added timezone dependent current time in custom status selector

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has redux changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
```
