### PR TITLE
Fixed the MM-33210 issue

### DIFF
--- a/actions/emoji_actions.jsx
+++ b/actions/emoji_actions.jsx
@@ -113,9 +113,13 @@ export function loadCustomEmojisIfNeeded(emojis) {
         const systemEmojis = EmojiIndicesByAlias;
         const customEmojisByName = getCustomEmojisByName(state);
         const nonExistentCustomEmoji = state.entities.emojis.nonExistentEmoji;
-        const emojisToLoad = new Set();
+        const emojisToLoad = [];
 
         emojis.forEach((emoji) => {
+            if (!emoji) {
+                return;
+            }
+
             if (systemEmojis.has(emoji)) {
                 // It's a system emoji, no need to fetch
                 return;
@@ -131,10 +135,10 @@ export function loadCustomEmojisIfNeeded(emojis) {
                 return;
             }
 
-            emojisToLoad.add(emoji);
+            emojisToLoad.push(emoji);
         });
 
-        dispatch(EmojiActions.getCustomEmojisByName(Array.from(emojisToLoad)));
+        dispatch(EmojiActions.getCustomEmojisByName(emojisToLoad));
         return {data: true};
     };
 }

--- a/actions/emoji_actions.jsx
+++ b/actions/emoji_actions.jsx
@@ -104,6 +104,10 @@ export function loadCustomEmojisForCustomStatusesByUserIds(userIds) {
 
 export function loadCustomEmojisIfNeeded(emojis) {
     return (dispatch, getState) => {
+        if (!emojis || emojis.length === 0) {
+            return {data: false};
+        }
+
         const state = getState();
         const customEmojiEnabled = isCustomEmojiEnabled(state);
         if (!customEmojiEnabled) {
@@ -139,6 +143,24 @@ export function loadCustomEmojisIfNeeded(emojis) {
         });
 
         dispatch(EmojiActions.getCustomEmojisByName(emojisToLoad));
+        return {data: true};
+    };
+}
+
+export function loadCustomStatusEmojisForPostList(posts) {
+    return (dispatch) => {
+        if (!posts || posts.length === 0) {
+            return {data: false};
+        }
+
+        const userIds = new Set();
+        Object.keys(posts).forEach((postId) => {
+            const post = posts[postId];
+            if (post.user_id) {
+                userIds.add(post.user_id);
+            }
+        });
+        dispatch(loadCustomEmojisForCustomStatusesByUserIds(userIds));
         return {data: true};
     };
 }

--- a/actions/emoji_actions.jsx
+++ b/actions/emoji_actions.jsx
@@ -2,12 +2,15 @@
 // See LICENSE.txt for license information.
 
 import * as EmojiActions from 'mattermost-redux/actions/emojis';
+import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {setRecentEmojis} from 'actions/local_storage';
-import {getEmojiMap, getRecentEmojis} from 'selectors/emojis';
+import {getEmojiMap, getRecentEmojis, isCustomEmojiEnabled} from 'selectors/emojis';
+import {isCustomStatusEnabled, makeGetCustomStatus} from 'selectors/views/custom_status';
 
 import {ActionTypes} from 'utils/constants';
+import {EmojiIndicesByAlias} from 'utils/emoji';
 
 export function loadRecentlyUsedCustomEmojis() {
     return async (dispatch, getState) => {
@@ -72,3 +75,67 @@ export function addRecentEmoji(alias) {
         dispatch(setRecentEmojis(recentEmojis));
     };
 }
+
+export function loadCustomEmojisForCustomStatusesByUserIds(userIds) {
+    return (dispatch, getState) => {
+        const state = getState();
+        const customEmojiEnabled = isCustomEmojiEnabled(state);
+        const customStatusEnabled = isCustomStatusEnabled(state);
+        if (!customEmojiEnabled || !customStatusEnabled) {
+            return {data: false};
+        }
+
+        const getCustomStatus = makeGetCustomStatus();
+        const emojisToLoad = new Set();
+
+        userIds.forEach((userId) => {
+            const customStatus = getCustomStatus(state, userId);
+            if (!customStatus || !customStatus.emoji) {
+                return;
+            }
+
+            emojisToLoad.add(customStatus.emoji);
+        });
+
+        dispatch(loadCustomEmojisIfNeeded(Array.from(emojisToLoad)));
+        return {data: true};
+    };
+}
+
+export function loadCustomEmojisIfNeeded(emojis) {
+    return (dispatch, getState) => {
+        const state = getState();
+        const customEmojiEnabled = isCustomEmojiEnabled(state);
+        if (!customEmojiEnabled) {
+            return {data: false};
+        }
+
+        const systemEmojis = EmojiIndicesByAlias;
+        const customEmojisByName = getCustomEmojisByName(state);
+        const nonExistentCustomEmoji = state.entities.emojis.nonExistentEmoji;
+        const emojisToLoad = new Set();
+
+        emojis.forEach((emoji) => {
+            if (systemEmojis.has(emoji)) {
+                // It's a system emoji, no need to fetch
+                return;
+            }
+
+            if (nonExistentCustomEmoji.has(emoji)) {
+                // We've previously confirmed this is not a custom emoji
+                return;
+            }
+
+            if (customEmojisByName.has(emoji)) {
+                // We have the emoji, no need to fetch
+                return;
+            }
+
+            emojisToLoad.add(emoji);
+        });
+
+        dispatch(EmojiActions.getCustomEmojisByName(Array.from(emojisToLoad)));
+        return {data: true};
+    };
+}
+

--- a/actions/status_actions.jsx
+++ b/actions/status_actions.jsx
@@ -10,6 +10,8 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import store from 'stores/redux_store.jsx';
 import {Constants} from 'utils/constants';
 
+import {loadCustomEmojisForCustomStatusesByUserIds} from './emoji_actions';
+
 export function loadStatusesForChannelAndSidebar() {
     return (dispatch, getState) => {
         const state = getState();
@@ -79,10 +81,12 @@ export function loadStatusesForProfilesMap(users) {
 export function loadStatusesByIds(userIds) {
     return (dispatch) => {
         if (userIds.length === 0) {
-            return;
+            return {data: false};
         }
 
         dispatch(getStatusesByIds(userIds));
+        dispatch(loadCustomEmojisForCustomStatusesByUserIds(userIds));
+        return {data: true};
     };
 }
 

--- a/actions/status_actions.jsx
+++ b/actions/status_actions.jsx
@@ -7,10 +7,9 @@ import {getPostsInCurrentChannel} from 'mattermost-redux/selectors/entities/post
 import {getDirectShowPreferences} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
+import {loadCustomEmojisForCustomStatusesByUserIds} from 'actions/emoji_actions';
 import store from 'stores/redux_store.jsx';
 import {Constants} from 'utils/constants';
-
-import {loadCustomEmojisForCustomStatusesByUserIds} from './emoji_actions';
 
 export function loadStatusesForChannelAndSidebar() {
     return (dispatch, getState) => {

--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -23,6 +23,7 @@ import * as Selectors from 'mattermost-redux/selectors/entities/users';
 import {legacyMakeFilterAutoclosedDMs, makeFilterManuallyClosedDMs} from 'mattermost-redux/selectors/entities/channel_categories';
 import {CategoryTypes} from 'mattermost-redux/constants/channel_categories';
 
+import {loadCustomEmojisForCustomStatusesByUserIds} from 'actions/emoji_actions';
 import {loadStatusesForProfilesList, loadStatusesForProfilesMap} from 'actions/status_actions.jsx';
 import {trackEvent} from 'actions/telemetry_actions.jsx';
 
@@ -32,8 +33,6 @@ import store from 'stores/redux_store.jsx';
 
 import * as Utils from 'utils/utils.jsx';
 import {Constants, Preferences, UserStatuses} from 'utils/constants';
-
-import {loadCustomEmojisForCustomStatusesByUserIds} from './emoji_actions';
 
 export const queue = new PQueue({concurrency: 4});
 const dispatch = store.dispatch;

--- a/actions/views/channel.js
+++ b/actions/views/channel.js
@@ -35,6 +35,7 @@ import {getChannelByName} from 'mattermost-redux/utils/channel_utils';
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
 import {openDirectChannelToUserId} from 'actions/channel_actions.jsx';
+import {loadCustomEmojisForCustomStatusesByUserIds} from 'actions/emoji_actions';
 import {getLastViewedChannelName} from 'selectors/local_storage';
 import {getLastPostsApiTimeForChannel} from 'selectors/views/channel';
 import {getSocketStatus} from 'selectors/views/websocket';
@@ -231,6 +232,16 @@ export function loadUnreads(channelId, prefetch = false) {
             };
         }
         const actions = [];
+        if (data.posts) {
+            const userIds = new Set();
+            Object.keys(data.posts).forEach((postId) => {
+                const post = data.posts[postId];
+                if (post.user_id) {
+                    userIds.add(post.user_id);
+                }
+            });
+            dispatch(loadCustomEmojisForCustomStatusesByUserIds(userIds));
+        }
 
         actions.push({
             type: ActionTypes.INCREASE_POST_VISIBILITY,
@@ -344,6 +355,17 @@ export function loadPosts({channelId, postId, type}) {
                 error: result.error,
                 moreToLoad: true,
             };
+        }
+
+        if (data.posts) {
+            const userIds = new Set();
+            Object.keys(data.posts).forEach((postid) => {
+                const post = data.posts[postid];
+                if (post.user_id) {
+                    userIds.add(post.user_id);
+                }
+            });
+            dispatch(loadCustomEmojisForCustomStatusesByUserIds(userIds));
         }
         actions.push({
             type: ActionTypes.INCREASE_POST_VISIBILITY,

--- a/actions/views/channel.js
+++ b/actions/views/channel.js
@@ -35,7 +35,7 @@ import {getChannelByName} from 'mattermost-redux/utils/channel_utils';
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
 import {openDirectChannelToUserId} from 'actions/channel_actions.jsx';
-import {loadCustomEmojisForCustomStatusesByUserIds} from 'actions/emoji_actions';
+import {loadCustomStatusEmojisForPostList} from 'actions/emoji_actions';
 import {getLastViewedChannelName} from 'selectors/local_storage';
 import {getLastPostsApiTimeForChannel} from 'selectors/views/channel';
 import {getSocketStatus} from 'selectors/views/websocket';
@@ -231,18 +231,9 @@ export function loadUnreads(channelId, prefetch = false) {
                 atOldestmessage: false,
             };
         }
-        const actions = [];
-        if (data.posts) {
-            const userIds = new Set();
-            Object.keys(data.posts).forEach((postId) => {
-                const post = data.posts[postId];
-                if (post.user_id) {
-                    userIds.add(post.user_id);
-                }
-            });
-            dispatch(loadCustomEmojisForCustomStatusesByUserIds(userIds));
-        }
+        dispatch(loadCustomStatusEmojisForPostList(data.posts));
 
+        const actions = [];
         actions.push({
             type: ActionTypes.INCREASE_POST_VISIBILITY,
             data: channelId,
@@ -357,16 +348,7 @@ export function loadPosts({channelId, postId, type}) {
             };
         }
 
-        if (data.posts) {
-            const userIds = new Set();
-            Object.keys(data.posts).forEach((postid) => {
-                const post = data.posts[postid];
-                if (post.user_id) {
-                    userIds.add(post.user_id);
-                }
-            });
-            dispatch(loadCustomEmojisForCustomStatusesByUserIds(userIds));
-        }
+        dispatch(loadCustomStatusEmojisForPostList(data.posts));
         actions.push({
             type: ActionTypes.INCREASE_POST_VISIBILITY,
             data: channelId,

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -73,6 +73,7 @@ import {syncPostsInChannel} from 'actions/views/channel';
 
 import {browserHistory} from 'utils/browser_history';
 import {loadChannelsForCurrentUser} from 'actions/channel_actions.jsx';
+import {loadCustomEmojisIfNeeded} from 'actions/emoji_actions';
 import {redirectUserToDefaultTeam} from 'actions/global_actions';
 import {handleNewPost} from 'actions/post_actions.jsx';
 import * as StatusActions from 'actions/status_actions.jsx';
@@ -965,6 +966,10 @@ export async function handleUserUpdatedEvent(msg) {
     const state = getState();
     const currentUser = getCurrentUser(state);
     const user = msg.data.user;
+    if (user && user.props) {
+        const customStatus = user.props.customStatus ? JSON.parse(user.props.customStatus) : undefined;
+        dispatch(loadCustomEmojisIfNeeded([customStatus?.emoji]));
+    }
 
     const config = getConfig(state);
     const license = getLicense(state);

--- a/components/custom_status/custom_status_emoji.tsx
+++ b/components/custom_status/custom_status_emoji.tsx
@@ -1,22 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import React, {useEffect} from 'react';
+import React from 'react';
 import {Tooltip} from 'react-bootstrap';
-import {useDispatch, useSelector} from 'react-redux';
-
-import {getCustomEmojiByName} from 'mattermost-redux/actions/emojis';
-import {getCustomEmojisByName as selectCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
+import {useSelector} from 'react-redux';
 
 import OverlayTrigger from 'components/overlay_trigger';
 import RenderEmoji from 'components/emoji/render_emoji';
-
 import {makeGetCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
-import {isCustomEmojiEnabled} from 'selectors/emojis';
-
 import {GlobalState} from 'types/store';
-
 import Constants from 'utils/constants';
-import {EmojiIndicesByAlias} from 'utils/emoji.jsx';
 
 interface ComponentProps {
     emojiSize?: number;
@@ -29,41 +21,12 @@ interface ComponentProps {
 }
 
 const CustomStatusEmoji = (props: ComponentProps) => {
-    const dispatch = useDispatch();
     const getCustomStatus = makeGetCustomStatus();
     const {emojiSize, emojiStyle, spanStyle, showTooltip, tooltipDirection, userID, onClick} = props;
 
     const customStatusEnabled = useSelector(isCustomStatusEnabled);
     const customStatus = useSelector((state: GlobalState) => getCustomStatus(state, userID));
     const isCustomStatusSet = Boolean(customStatusEnabled && customStatus && customStatus.emoji);
-
-    const customEmojiEnabled = useSelector(isCustomEmojiEnabled);
-    const systemEmojis = EmojiIndicesByAlias;
-    const customEmojisByName = useSelector(selectCustomEmojisByName);
-    const nonExistentCustomEmoji = useSelector((state: GlobalState) => state.entities.emojis.nonExistentEmoji);
-
-    useEffect(() => {
-        if (!isCustomStatusSet || !customEmojiEnabled) {
-            return;
-        }
-
-        if (systemEmojis.has(customStatus.emoji)) {
-            // It's a system emoji, no need to fetch
-            return;
-        }
-
-        if (nonExistentCustomEmoji.has(customStatus.emoji)) {
-            // We've previously confirmed this is not a custom emoji
-            return;
-        }
-
-        if (customEmojisByName.has(customStatus.emoji)) {
-            // We have the emoji, no need to fetch
-            return;
-        }
-
-        dispatch(getCustomEmojiByName(customStatus.emoji));
-    }, [customStatusEnabled, customStatus, customEmojiEnabled, systemEmojis, customEmojisByName, nonExistentCustomEmoji]);
 
     if (!isCustomStatusSet) {
         return null;

--- a/components/custom_status/custom_status_modal.tsx
+++ b/components/custom_status/custom_status_modal.tsx
@@ -61,17 +61,22 @@ const CustomStatusModal: React.FC<Props> = (props: Props) => {
     const isCurrentCustomStatusSet = currentCustomStatus.text || currentCustomStatus.emoji;
     const firstTimeModalOpened = useSelector((state: GlobalState) => showStatusDropdownPulsatingDot(state));
 
-    const emojisToLoad = new Set<string>();
-    recentCustomStatuses.forEach((customStatus: UserCustomStatus) => emojisToLoad.add(customStatus.emoji));
-    dispatch(loadCustomEmojisIfNeeded(emojisToLoad));
-
     const handleCustomStatusInitializationState = () => {
         if (firstTimeModalOpened) {
             dispatch(setCustomStatusInitialisationState({[Preferences.CUSTOM_STATUS_MODAL_VIEWED]: true}));
         }
     };
 
-    useEffect(handleCustomStatusInitializationState, []);
+    const loadCustomEmojisForRecentStatuses = () => {
+        const emojisToLoad = new Set<string>();
+        recentCustomStatuses.forEach((customStatus: UserCustomStatus) => emojisToLoad.add(customStatus.emoji));
+        dispatch(loadCustomEmojisIfNeeded(emojisToLoad));
+    };
+
+    useEffect(() => {
+        handleCustomStatusInitializationState();
+        loadCustomEmojisForRecentStatuses();
+    }, []);
 
     const handleSetStatus = () => {
         const customStatus = {

--- a/components/custom_status/custom_status_modal.tsx
+++ b/components/custom_status/custom_status_modal.tsx
@@ -70,7 +70,7 @@ const CustomStatusModal: React.FC<Props> = (props: Props) => {
     const loadCustomEmojisForRecentStatuses = () => {
         const emojisToLoad = new Set<string>();
         recentCustomStatuses.forEach((customStatus: UserCustomStatus) => emojisToLoad.add(customStatus.emoji));
-        dispatch(loadCustomEmojisIfNeeded(emojisToLoad));
+        dispatch(loadCustomEmojisIfNeeded(Array.from(emojisToLoad)));
     };
 
     useEffect(() => {

--- a/components/custom_status/custom_status_modal.tsx
+++ b/components/custom_status/custom_status_modal.tsx
@@ -11,6 +11,7 @@ import {Preferences} from 'mattermost-redux/constants';
 import {UserCustomStatus} from 'mattermost-redux/types/users';
 import {Emoji} from 'mattermost-redux/types/emojis';
 
+import {loadCustomEmojisIfNeeded} from 'actions/emoji_actions';
 import GenericModal from 'components/generic_modal';
 import EmojiIcon from 'components/widgets/icons/emoji_icon';
 import EmojiPickerOverlay from 'components/emoji_picker/emoji_picker_overlay.jsx';
@@ -59,6 +60,10 @@ const CustomStatusModal: React.FC<Props> = (props: Props) => {
     const isStatusSet = emoji || text;
     const isCurrentCustomStatusSet = currentCustomStatus.text || currentCustomStatus.emoji;
     const firstTimeModalOpened = useSelector((state: GlobalState) => showStatusDropdownPulsatingDot(state));
+
+    const emojisToLoad = new Set<string>();
+    recentCustomStatuses.forEach((customStatus: UserCustomStatus) => emojisToLoad.add(customStatus.emoji));
+    dispatch(loadCustomEmojisIfNeeded(emojisToLoad));
 
     const handleCustomStatusInitializationState = () => {
         if (firstTimeModalOpened) {

--- a/components/more_direct_channels/index.ts
+++ b/components/more_direct_channels/index.ts
@@ -10,7 +10,6 @@ import {intersectionBy} from 'lodash';
 import {
     getProfiles,
     getProfilesInTeam,
-    getStatusesByIds,
     getTotalUsersStats,
     searchProfiles,
 } from 'mattermost-redux/actions/users';
@@ -38,7 +37,7 @@ import {memoizeResult} from 'mattermost-redux/utils/helpers';
 
 import {Constants} from 'utils/constants';
 import {openDirectChannelToUserId, openGroupChannelToUserIds} from 'actions/channel_actions';
-import {loadStatusesForProfilesList} from 'actions/status_actions.jsx';
+import {loadStatusesForProfilesList, loadStatusesByIds} from 'actions/status_actions.jsx';
 import {loadProfilesForGroupChannels} from 'actions/user_actions.jsx';
 import {setModalSearchTerm} from 'actions/views/search';
 
@@ -137,7 +136,7 @@ const filterDirectChannels = memoizeResult((channels: Record<string, Channel>, u
 type Actions = {
     getProfiles: (page?: number | undefined, perPage?: number | undefined, options?: any) => Promise<any>;
     getProfilesInTeam: (teamId: string, page: number, perPage?: number | undefined, sort?: string | undefined, options?: any) => Promise<any>;
-    getStatusesByIds: (userIds: string[]) => ActionFunc;
+    loadStatusesByIds: (userIds: string[]) => ActionFunc;
     getTotalUsersStats: () => ActionFunc;
     loadStatusesForProfilesList: (users: any) => {
         data: boolean;
@@ -155,7 +154,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
         actions: bindActionCreators<ActionCreatorsMapObject<ActionFunc | GenericAction>, Actions>({
             getProfiles,
             getProfilesInTeam,
-            getStatusesByIds,
+            loadStatusesByIds,
             getTotalUsersStats,
             loadStatusesForProfilesList,
             loadProfilesForGroupChannels,

--- a/components/more_direct_channels/more_direct_channels.tsx
+++ b/components/more_direct_channels/more_direct_channels.tsx
@@ -89,7 +89,7 @@ type Props = {
     actions: {
         getProfiles: (page?: number | undefined, perPage?: number | undefined, options?: any) => Promise<any>;
         getProfilesInTeam: (teamId: string, page: number, perPage?: number | undefined, sort?: string | undefined, options?: any) => Promise<any>;
-        getStatusesByIds: (userIds: string[]) => void;
+        loadStatusesByIds: (userIds: string[]) => void;
         getTotalUsersStats: () => void;
         loadStatusesForProfilesList: (users: any) => {
             data: boolean;
@@ -201,7 +201,7 @@ export default class MoreDirectChannels extends React.PureComponent<Props, State
             map((user) => user.id);
 
         if (missingStatusByIds.length > 0) {
-            this.props.actions.getStatusesByIds(missingStatusByIds);
+            this.props.actions.loadStatusesByIds(missingStatusByIds);
         }
     }
 


### PR DESCRIPTION
Made loadCustomEmojisForCustomStatusesByUserIds and loadCustomEmojisIfNeeded actions
Added the call for loadCustomEmojisForCustomStatusesByUserIds in status actions
Added the call for loadCustomEmojisForCustomStatusesByUserIds in loadProfiles for DM and GM
Added the call for loadCustomEmojisForCustomStatusesByUserIds in loadPosts and loadUnreads
Removed the loading custom emoji logic from custom status emoji component
Added the call for loadCustomEmojisIfNeeded in custom status modal for suggestions
Replaced getStatusesByIds with loadStatusesByIds in more direct channels modal

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has redux changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
```
