### PR TITLE
Solved redirecting issue and the text for "Back to {team}"

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -800,6 +800,10 @@ function handleDeleteTeamEvent(msg) {
             {type: TeamTypes.UPDATED_TEAM, data: deletedTeam},
         ]));
 
+        if (browserHistory.location?.pathname === `/admin_console/user_management/teams/${deletedTeam.id}`) {
+            return;
+        }
+
         if (newTeamId) {
             dispatch({type: TeamTypes.SELECT_TEAM, data: newTeamId});
             const globalState = getState();

--- a/components/admin_console/team_channel_settings/team/list/team_list.tsx
+++ b/components/admin_console/team_channel_settings/team/list/team_list.tsx
@@ -228,7 +228,7 @@ export default class TeamList extends React.PureComponent<Props, State> {
                             <div className='TeamList_nameText'>
                                 <b data-testid='team-display-name'>
                                     {team.display_name}
-                                    {team.delete_at !== 0 &&
+                                    {team.delete_at !== 0 && (
                                         <span className='archived-label'>
                                             {'  '}
                                             <FormattedMessage
@@ -236,7 +236,7 @@ export default class TeamList extends React.PureComponent<Props, State> {
                                                 defaultMessage='(Archived)'
                                             />
                                         </span>
-                                    }
+                                    )}
                                 </b>
                                 {team.description && (
                                     <div className='TeamList_descriptionText'>

--- a/components/backstage/components/backstage_navbar.jsx
+++ b/components/backstage/components/backstage_navbar.jsx
@@ -11,31 +11,37 @@ import BackIcon from 'components/widgets/icons/fa_back_icon';
 export default class BackstageNavbar extends React.PureComponent {
     static get propTypes() {
         return {
-            team: PropTypes.object.isRequired,
+            team: PropTypes.object,
             siteName: PropTypes.string,
         };
     }
 
     render() {
-        if (!this.props.team) {
-            return null;
-        }
+        const {team} = this.props;
+        const teamExists = team?.delete_at === 0;
 
         return (
             <div className='backstage-navbar'>
                 <Link
                     className='backstage-navbar__back'
-                    to={`/${this.props.team.name}`}
+                    to={`/${teamExists ? this.props.team.name : ''}`}
                 >
                     <BackIcon/>
                     <span>
-                        <FormattedMessage
-                            id='backstage_navbar.backToMattermost'
-                            defaultMessage='Back to {siteName}'
-                            values={{
-                                siteName: this.props.siteName ? this.props.siteName : this.props.team.name,
-                            }}
-                        />
+                        {teamExists ? (
+                            <FormattedMessage
+                                id='backstage_navbar.backToMattermost'
+                                defaultMessage='Back to {siteName}'
+                                values={{
+                                    siteName: this.props.siteName ? this.props.siteName : this.props.team.name,
+                                }}
+                            />
+                        ) : (
+                            <FormattedMessage
+                                id='backstage_navbar.backToHome'
+                                defaultMessage='Back to home'
+                            />
+                        )}
                     </span>
                 </Link>
             </div>

--- a/components/backstage/components/backstage_navbar.jsx
+++ b/components/backstage/components/backstage_navbar.jsx
@@ -38,8 +38,8 @@ export default class BackstageNavbar extends React.PureComponent {
                             />
                         ) : (
                             <FormattedMessage
-                                id='backstage_navbar.backToHome'
-                                defaultMessage='Back to home'
+                                id='backstage_navbar.back'
+                                defaultMessage='Back'
                             />
                         )}
                     </span>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2510,6 +2510,7 @@
   "avatars.overflowUnnamedOnly": "{overflowUnnamedCount, plural, =1 {one other} other {# others}}",
   "avatars.overflowUsers": "{overflowUnnamedCount, plural, =0 {{names}} =1 {{names} and one other} other {{names} and # others}}",
   "backstage_list.search": "Search",
+  "backstage_navbar.backToHome": "Back to home",
   "backstage_navbar.backToMattermost": "Back to {siteName}",
   "backstage_sidebar.bots": "Bot Accounts",
   "backstage_sidebar.emoji": "Custom Emoji",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2510,7 +2510,7 @@
   "avatars.overflowUnnamedOnly": "{overflowUnnamedCount, plural, =1 {one other} other {# others}}",
   "avatars.overflowUsers": "{overflowUnnamedCount, plural, =0 {{names}} =1 {{names} and one other} other {{names} and # others}}",
   "backstage_list.search": "Search",
-  "backstage_navbar.backToHome": "Back to home",
+  "backstage_navbar.back": "Back",
   "backstage_navbar.backToMattermost": "Back to {siteName}",
   "backstage_sidebar.bots": "Bot Accounts",
   "backstage_sidebar.emoji": "Custom Emoji",


### PR DESCRIPTION
Solved redirecting issue by checking for pathname in the websocket handler
Refactored some code according to review fixes
Modified backstage_navbar to display "back to home" if team is not there
Added localization ids

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has redux changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
```
