### PR TITLE
UI review fixes

### DIFF
--- a/components/custom_status/__snapshots__/custom_status_suggestion.test.tsx.snap
+++ b/components/custom_status/__snapshots__/custom_status_suggestion.test.tsx.snap
@@ -20,12 +20,35 @@ exports[`components/custom_status/custom_status_emoji should match snapshot 1`] 
     text=""
     tooltipDirection="top"
   />
+</div>
+`;
+
+exports[`components/custom_status/custom_status_emoji should match snapshot with duration 1`] = `
+<div
+  className="statusSuggestion__row cursor--pointer"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <div
+    className="statusSuggestion__icon"
+  >
+    <Memo(RenderEmoji)
+      emojiName=""
+      size={20}
+    />
+  </div>
+  <CustomStatusText
+    className="statusSuggestion__text with_duration"
+    text=""
+    tooltipDirection="top"
+  />
   <span
     className="statusSuggestion__duration"
   >
     <FormattedMessage
-      defaultMessage="Don't clear"
-      id="custom_status.expiry_dropdown.dont_clear"
+      defaultMessage="Today"
+      id="custom_status.expiry_dropdown.today"
     />
   </span>
 </div>

--- a/components/custom_status/custom_status.scss
+++ b/components/custom_status/custom_status.scss
@@ -207,9 +207,12 @@
         height: 20px;
         text-overflow: ellipsis;
         white-space: nowrap;
-        max-width: 73%;
-    }
 
+        &.with_duration {
+            max-width: 62%;
+        }
+    }
+    
     &__duration {
         margin-left: 8px;
         font-weight: 400;

--- a/components/custom_status/custom_status_suggestion.test.tsx
+++ b/components/custom_status/custom_status_suggestion.test.tsx
@@ -27,6 +27,21 @@ describe('components/custom_status/custom_status_emoji', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    it('should match snapshot with duration', () => {
+        const props = {
+            ...baseProps,
+            status: {
+                ...baseProps.status,
+                duration: CustomStatusDuration.TODAY,
+            },
+        };
+        const wrapper = shallow(
+            <CustomStatusSuggestion {...props}/>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
     it('should call handleSuggestionClick when click occurs on div', () => {
         const wrapper = shallow(
             <CustomStatusSuggestion {...baseProps}/>,

--- a/components/custom_status/custom_status_suggestion.tsx
+++ b/components/custom_status/custom_status_suggestion.tsx
@@ -3,6 +3,7 @@
 import React, {useState} from 'react';
 import {Tooltip} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
+import classNames from 'classnames';
 
 import {UserCustomStatus} from 'mattermost-redux/types/users';
 
@@ -77,9 +78,11 @@ const CustomStatusSuggestion: React.FC<Props> = (props: Props) => {
             <CustomStatusText
                 text={text}
                 tooltipDirection='top'
-                className='statusSuggestion__text'
+                className={classNames('statusSuggestion__text', {
+                    with_duration: duration,
+                })}
             />
-            {duration !== undefined && (
+            {duration && (
                 <span className='statusSuggestion__duration'>
                     <FormattedMessage
                         id={durationValues[duration].id}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2840,7 +2840,7 @@
   "custom_emoji.header": "Custom Emoji",
   "custom_status.expiry_dropdown.choose_date_and_time": "Choose date and time",
   "custom_status.expiry_dropdown.clear_after": "Clear after",
-  "custom_status.expiry_dropdown.date_and_time": "Date and Time",
+  "custom_status.expiry_dropdown.date_and_time": "Custom Date and Time",
   "custom_status.expiry_dropdown.dont_clear": "Don't clear",
   "custom_status.expiry_dropdown.four_hours": "4 hours",
   "custom_status.expiry_dropdown.one_hour": "1 hour",

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -1709,11 +1709,11 @@ export const durationValues = {
     },
     [DATE_AND_TIME]: {
         id: t('custom_status.expiry_dropdown.date_and_time'),
-        defaultMessage: 'Date and Time',
+        defaultMessage: 'Custom Date and Time',
     },
     [CUSTOM_DATE_TIME]: {
         id: t('custom_status.expiry_dropdown.date_and_time'),
-        defaultMessage: 'Date and Time',
+        defaultMessage: 'Custom Date and Time',
     },
 };
 


### PR DESCRIPTION
Changed the text for Date and time to Custom Date and Time
Removed duration from the suggestions if duration is Don't clear
Changed the width of the suggestions dynamically based on the presence of duration
Added a unit test for the suggestion and updated the existing snapshot

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has redux changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
